### PR TITLE
perf(cnf): encode asserted top-level structure without root Tseitin variables

### DIFF
--- a/include/somtparser/frontend/parser.h
+++ b/include/somtparser/frontend/parser.h
@@ -4080,6 +4080,11 @@ namespace SOMTParser{
         std::shared_ptr<DAGNode>                toTseitinCNF(std::shared_ptr<DAGNode> expr, 
                                                             std::unordered_map<std::shared_ptr<DAGNode>, std::shared_ptr<DAGNode>>& visited, 
                                                             std::vector<std::shared_ptr<DAGNode>>& clauses);
+        // encode a formula in asserted (top-level, positive) position without a
+        // Tseitin variable for its root connective; see conv_parser.cpp
+        void                                    assertTopCNF(std::shared_ptr<DAGNode> expr,
+                                                            std::unordered_map<std::shared_ptr<DAGNode>, std::shared_ptr<DAGNode>>& visited,
+                                                            std::vector<std::shared_ptr<DAGNode>>& clauses);
         std::shared_ptr<DAGNode>                toTseitinXor(std::shared_ptr<DAGNode> a, std::shared_ptr<DAGNode> b, std::vector<std::shared_ptr<DAGNode>>& clauses);
         std::shared_ptr<DAGNode>                toTseitinEq(std::shared_ptr<DAGNode> a, std::shared_ptr<DAGNode> b, std::vector<std::shared_ptr<DAGNode>>& clauses);
         std::shared_ptr<DAGNode>                toTseitinDistinct(std::shared_ptr<DAGNode> a, std::shared_ptr<DAGNode> b, std::vector<std::shared_ptr<DAGNode>>& clauses);

--- a/src/frontend/conv_parser.cpp
+++ b/src/frontend/conv_parser.cpp
@@ -801,6 +801,124 @@ namespace SOMTParser {
         return is_changed;
     }
 
+    // Encode a formula that sits in asserted (top-level, positive) position.
+    // The root connective needs no Tseitin definition variable: conjunctions
+    // split into independently asserted conjuncts, literals become unit
+    // clauses, and a disjunction/xor/implication/iff root is emitted as its
+    // direct clausal form. Only nested boolean structure goes through
+    // toTseitinCNF and receives definition variables.
+    void Parser::assertTopCNF(std::shared_ptr<DAGNode> expr,
+                              std::unordered_map<std::shared_ptr<DAGNode>, std::shared_ptr<DAGNode>>& visited,
+                              std::vector<std::shared_ptr<DAGNode>>& clauses) {
+        if(expr->isLet()){
+            assertTopCNF(expandLet(expr), visited, clauses);
+            return;
+        }
+        if(expr->isAtom()){
+            // map the atom to its boolean abstraction literal (no clauses emitted)
+            clauses.emplace_back(toTseitinCNF(expr, visited, clauses));
+            return;
+        }
+        if(expr->isLiteral()){
+            if(expr->isTrue()){
+                return; // asserting true adds no constraint
+            }
+            clauses.emplace_back(expr);
+            return;
+        }
+        if(expr->isAnd()){
+            // each conjunct is asserted independently
+            for(size_t i = 0; i < expr->getChildrenSize(); i++){
+                assertTopCNF(expr->getChild(i), visited, clauses);
+            }
+            return;
+        }
+        if(expr->isNot()){
+            // NNF pushes negation onto atoms; an unabstracted ¬atom lands here
+            std::shared_ptr<DAGNode> lit = toTseitinCNF(expr->getChild(0), visited, clauses);
+            clauses.emplace_back(mkNot(lit));
+            return;
+        }
+        if(expr->isOr()){
+            // an asserted disjunction is itself a single clause
+            std::vector<std::shared_ptr<DAGNode>> lits;
+            for(size_t i = 0; i < expr->getChildrenSize(); i++){
+                lits.emplace_back(toTseitinCNF(expr->getChild(i), visited, clauses));
+            }
+            clauses.emplace_back(mkOr(lits));
+            return;
+        }
+        if(expr->isXor()){
+            // fold all but the last operand through Tseitin, then assert the
+            // final pair directly: r xor l <=> (r or l) and (¬r or ¬l)
+            std::vector<std::shared_ptr<DAGNode>> lits;
+            for(size_t i = 0; i < expr->getChildrenSize(); i++){
+                lits.emplace_back(toTseitinCNF(expr->getChild(i), visited, clauses));
+            }
+            if(lits.size() == 1){
+                clauses.emplace_back(lits[0]);
+                return;
+            }
+            std::shared_ptr<DAGNode> r = lits[0];
+            for(size_t i = 1; i + 1 < lits.size(); i++){
+                r = toTseitinXor(r, lits[i], clauses);
+            }
+            std::shared_ptr<DAGNode> last = lits.back();
+            clauses.emplace_back(mkOr({r, last}));
+            clauses.emplace_back(mkOr({mkNot(r), mkNot(last)}));
+            return;
+        }
+        if(expr->isImplies()){
+            // (=> a1 ... an b) asserted is the single clause ¬a1 ∨ ... ∨ ¬an ∨ b
+            std::vector<std::shared_ptr<DAGNode>> lits;
+            for(size_t i = 0; i < expr->getChildrenSize(); i++){
+                lits.emplace_back(toTseitinCNF(expr->getChild(i), visited, clauses));
+            }
+            if(lits.size() == 1){
+                clauses.emplace_back(lits[0]);
+                return;
+            }
+            std::vector<std::shared_ptr<DAGNode>> or_children;
+            for(size_t i = 0; i + 1 < lits.size(); i++){
+                or_children.emplace_back(mkNot(lits[i]));
+            }
+            or_children.emplace_back(lits.back());
+            clauses.emplace_back(mkOr(or_children));
+            return;
+        }
+        if(expr->isEq() && expr->getChildrenSize() >= 2){
+            bool all_bool = true;
+            for(size_t i = 0; i < expr->getChildrenSize(); i++){
+                if(!expr->getChild(i)->getSort()->isBool()){
+                    all_bool = false;
+                    break;
+                }
+            }
+            if(all_bool){
+                // asserted iff chain: a1 = ai for all i, two binary clauses each
+                std::vector<std::shared_ptr<DAGNode>> lits;
+                for(size_t i = 0; i < expr->getChildrenSize(); i++){
+                    lits.emplace_back(toTseitinCNF(expr->getChild(i), visited, clauses));
+                }
+                for(size_t i = 1; i < lits.size(); i++){
+                    clauses.emplace_back(mkOr({mkNot(lits[0]), lits[i]}));
+                    clauses.emplace_back(mkOr({lits[0], mkNot(lits[i])}));
+                }
+                return;
+            }
+        }
+        if(expr->isDistinct() && expr->getChildrenSize() == 2 &&
+           expr->getChild(0)->getSort()->isBool() && expr->getChild(1)->getSort()->isBool()){
+            std::shared_ptr<DAGNode> a = toTseitinCNF(expr->getChild(0), visited, clauses);
+            std::shared_ptr<DAGNode> b = toTseitinCNF(expr->getChild(1), visited, clauses);
+            clauses.emplace_back(mkOr({a, b}));
+            clauses.emplace_back(mkOr({mkNot(a), mkNot(b)}));
+            return;
+        }
+        // anything else: define the subformula and assert its literal
+        clauses.emplace_back(toTseitinCNF(expr, visited, clauses));
+    }
+
     // convert a list of expressions to CNF (a large AND node, whose children are all OR clauses)
     std::shared_ptr<DAGNode> Parser::toCNF(std::vector<std::shared_ptr<DAGNode>> exprs) {
         // make a large AND node -> the same atom will use the same variable 
@@ -961,13 +1079,17 @@ namespace SOMTParser {
             cnf = new_expr;
         }
         else{
-            // convert to CNF using Tseitin transformation
+            // convert to CNF: the asserted root (and any top-level conjunction)
+            // is encoded directly; only nested structure gets Tseitin variables
             std::vector<std::shared_ptr<DAGNode>> clauses;
-            std::shared_ptr<DAGNode> tseitin_cnf = toTseitinCNF(new_expr, clauses);
-            clauses.emplace_back(tseitin_cnf);
+            std::unordered_map<std::shared_ptr<DAGNode>, std::shared_ptr<DAGNode>> visited;
+            assertTopCNF(new_expr, visited, clauses);
 
-            // if there is only one clause, return it directly
-            if (clauses.size() == 1) {
+            if(clauses.empty()){
+                cnf = mkTrue();
+            }
+            else if (clauses.size() == 1) {
+                // if there is only one clause, return it directly
                 cnf = clauses[0];
             }
             else{

--- a/test/python/test_convert.py
+++ b/test/python/test_convert.py
@@ -84,6 +84,67 @@ class TestCNF:
         assert not p.is_cnf(f)
 
 
+class TestCNFAssertedPosition:
+    """Top-level (asserted) structure is encoded directly: conjunctions are
+    split into independently asserted conjuncts, literals become unit clauses,
+    and an asserted or/xor/implies is emitted as its clausal form. No Tseitin
+    definition variable is introduced for the root connective."""
+
+    def test_atomic_conjuncts_become_units(self, p):
+        # (and (xor A B) C) plus D: only the xor needs encoding (2 clauses);
+        # C and D are asserted directly as unit clauses.
+        f1 = p.expr("(and (xor (>= x 1) (>= y 2)) (>= y -5))")
+        f2 = p.expr("(= x y)")
+        cnf = p.to_cnf([f1, f2])
+        assert p.is_cnf(cnf)
+        assert cnf.is_and
+        clauses = cnf.children
+        assert len(clauses) == 4
+        units = [c for c in clauses if not c.is_or]
+        binaries = [c for c in clauses if c.is_or]
+        assert len(units) == 2 and len(binaries) == 2
+        assert all(c.num_children == 2 for c in binaries)
+        # exactly the 4 atom abstractions -- no extra definition variables
+        assert len(p.cnf_bool_vars()) == 4
+
+    def test_asserted_disjunction_is_single_clause(self, p):
+        cnf = p.to_cnf(p.expr("(or (> x 0) (< y 2) (= x y))"))
+        assert cnf.is_or
+        assert cnf.num_children == 3
+        assert len(p.cnf_bool_vars()) == 3
+
+    def test_asserted_implies_is_single_clause(self, p):
+        cnf = p.to_cnf(p.expr("(=> (> x 0) (< y 2))"))
+        assert cnf.is_or
+        assert cnf.num_children == 2
+
+    def test_nested_structure_still_gets_definitions(self, p):
+        # (or (and A B) C): the nested conjunction still needs a definition
+        # variable, so the result is the top clause plus definition clauses.
+        cnf = p.to_cnf(p.expr("(or (and (> x 0) (< x 9)) (= x 100))"))
+        assert p.is_cnf(cnf)
+        assert cnf.is_and
+        assert cnf.num_children > 1
+
+    def test_asserted_xor_semantics_over_booleans(self):
+        # Over Boolean variables no abstraction happens, so the CNF can be
+        # evaluated directly and compared with the original formula.
+        import itertools
+
+        q = sp.parse("(declare-const a Bool)(declare-const b Bool)(declare-const c Bool)")
+        f = q.expr("(and (xor a b) c)")
+        cnf = q.to_cnf(f)
+        assert q.is_cnf(cnf)
+        for va, vb, vc in itertools.product([True, False], repeat=3):
+            m = sp.Model()
+            m.add("a", q.true_() if va else q.false_())
+            m.add("b", q.true_() if vb else q.false_())
+            m.add("c", q.true_() if vc else q.false_())
+            expected = (va != vb) and vc
+            assert q.evaluate(f, m).value == expected, (va, vb, vc)
+            assert q.evaluate(cnf, m).value == expected, (va, vb, vc)
+
+
 class TestTseitin:
     def test_standalone_tseitin(self, p):
         f = p.expr("(or (and (> x 0) (< x 9)) (= x 100))")


### PR DESCRIPTION
## Summary

`toCNF` previously handed the entire assertion conjunction to the polarity-blind `toTseitinCNF`, so even the asserted root AND received a definition variable, and atomic conjuncts were folded into that variable's biconditional clauses instead of being asserted directly.

For

```smt2
(assert (and (xor (>= x 1) (>= y 2)) (>= z 3)))
(assert (= obj (+ y z)))
```

the old encoding produced **9 clauses + 2 auxiliary variables**; the new one produces exactly

```
(and (or A' B') (or (not A') (not B')) C' D')
```

— **4 clauses, no auxiliary variables** beyond the atom abstraction.

## Approach

New `assertTopCNF` handles formulas in asserted (top-level, positive) position:

- root conjunctions split into independently asserted conjuncts (recursively)
- literals / atoms become unit clauses
- an asserted `or` is emitted as a single clause; `xor` as its two-clause direct form (n-ary folds all but the last pair through Tseitin); `=>`, Boolean `=`/`distinct` likewise get their direct clausal forms
- only nested Boolean structure still goes through `toTseitinCNF` and receives definition variables

Because nested definitions keep full biconditional clauses, the result stays equivalent to the input after projecting out auxiliary variables (not merely equisatisfiable). `toTseitinCNF` itself is unchanged.

## Testing

- new `TestCNFAssertedPosition` (5 tests): clause/variable counts for the motivating example, single-clause forms for asserted `or`/`=>`, nested structure still getting definitions, and an exhaustive 8-assignment semantic-equivalence check over Boolean variables
- full suites pass: **188/188 pytest, 36/36 C++ tests**

🤖 Generated with [Claude Code](https://claude.com/claude-code)