### PR TITLE
Backport printer fixes and theory support from the SMTStabilizer fork

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -55,6 +55,21 @@ All contributors will be recognized in this file. When you make your first contr
 <!-- Format: **Your Name** - *Brief description of contribution* -->
 <!-- Example: **John Doe** - *Bug fixes in expression parser* -->
 
+## Acknowledgements
+
+These are not project contributors, but their published work fed back into
+SOMTParser and deserves credit.
+
+- **SMTStabilizer** (<https://github.com/shaowei-cai-group/SMTStabilizer>, MIT,
+  © 2026 Xiang Zhang) vendors and extends SOMTParser's parser. Reviewing that
+  fork surfaced several printer bugs on our side (the `bv2int`/`int2bv`
+  conversions printing as `UNKNOWN_KIND`, the regex sort printing as
+  `(RegEx String)` instead of `RegLan`, and the datatype tester printing in the
+  legacy `(is-C x)` form), and its implementations of the tuple theory,
+  `((_ update <selector>) t v)`, the SMT-LIB 2.7 `ubv_to_int`/`sbv_to_int`
+  spellings and term-annotation preservation were used as the reference when
+  adding those features here. The individual call sites carry inline notes.
+
 ---
 
 ## Contact

--- a/include/somtparser/core/kind.h
+++ b/include/somtparser/core/kind.h
@@ -73,6 +73,9 @@ namespace SOMTParser{
         NT_BV_SHL,NT_BV_LSHR,NT_BV_ASHR,
         NT_BV_ULT,NT_BV_ULE,NT_BV_UGT,NT_BV_UGE,NT_BV_SLT,NT_BV_SLE,NT_BV_SGT,NT_BV_SGE,
         NT_BV_CONCAT,NT_BV_TO_NAT,NT_NAT_TO_BV,NT_BV_TO_INT,
+        // SMT-LIB 2.7 spellings of the bitvector->integer conversions
+        // (ubv_to_int/sbv_to_int); ported from the SMTStabilizer fork.
+        NT_UBV_TO_INT,NT_SBV_TO_INT,
         // BITVECTOR FUNCTIONS (in parseOper with args and params)
         NT_INT_TO_BV,NT_BV_EXTRACT,NT_BV_REPEAT,NT_BV_ZERO_EXT,NT_BV_SIGN_EXT,NT_BV_ROTATE_LEFT,NT_BV_ROTATE_RIGHT,
         
@@ -116,6 +119,18 @@ namespace SOMTParser{
         NT_UF_APPLY,
         // DATATYPE OPERATIONS
         NT_DT_CONSTRUCTOR, NT_DT_SELECTOR, NT_DT_TESTER, NT_DT_MATCH,
+        // ((_ update <selector>) t v) — functional record update; ported from
+        // the SMTStabilizer fork.
+        NT_DT_UPDATER,
+
+        // TUPLE OPERATIONS — ported from the SMTStabilizer fork.
+        NT_TUPLE_CONSTRUCTOR, NT_TUPLE_UNIT, NT_TUPLE_SELECT, NT_TUPLE_UPDATE, NT_TUPLE_PROJECT,
+
+        // TERM ANNOTATIONS: (! <term> :pattern (...) :qid q ...).
+        // NT_ATTRIBUTE is the annotated term itself (child 0 is the term, the
+        // remaining children are the annotations); ported from the
+        // SMTStabilizer fork.
+        NT_ATTRIBUTE, NT_PATTERN, NT_NO_PATTERN, NT_WEIGHT, NT_QID,
         
         // ARITHMETIC CONSTANTS
         NT_CONST_PI,NT_CONST_E,NT_INFINITY,NT_NAN,NT_EPSILON,NT_POS_INFINITY,NT_NEG_INFINITY,NT_POS_EPSILON,NT_NEG_EPSILON,
@@ -307,6 +322,9 @@ namespace SOMTParser{
         {"nat2bv", NODE_KIND::NT_NAT_TO_BV},
         {"bv2int", NODE_KIND::NT_BV_TO_INT},
         {"int2bv", NODE_KIND::NT_INT_TO_BV},
+        // SMT-LIB 2.7 spellings (ported from the SMTStabilizer fork)
+        {"ubv_to_int", NODE_KIND::NT_UBV_TO_INT},
+        {"sbv_to_int", NODE_KIND::NT_SBV_TO_INT},
         {"extract", NODE_KIND::NT_BV_EXTRACT},
         {"repeat", NODE_KIND::NT_BV_REPEAT},
         {"zero_extend", NODE_KIND::NT_BV_ZERO_EXT},
@@ -355,6 +373,12 @@ namespace SOMTParser{
         {"fp.isPositive", NODE_KIND::NT_FP_IS_POS},
         {"select", NODE_KIND::NT_SELECT},
         {"store", NODE_KIND::NT_STORE},
+        // TUPLE THEORY — ported from the SMTStabilizer fork.
+        {"tuple", NODE_KIND::NT_TUPLE_CONSTRUCTOR},
+        {"tuple.unit", NODE_KIND::NT_TUPLE_UNIT},
+        {"tuple.select", NODE_KIND::NT_TUPLE_SELECT},
+        {"tuple.update", NODE_KIND::NT_TUPLE_UPDATE},
+        {"tuple.project", NODE_KIND::NT_TUPLE_PROJECT},
         {"str.len", NODE_KIND::NT_STR_LEN},
         {"str.++", NODE_KIND::NT_STR_CONCAT},
         {"str.substr", NODE_KIND::NT_STR_SUBSTR},

--- a/include/somtparser/core/options.h
+++ b/include/somtparser/core/options.h
@@ -38,7 +38,9 @@ namespace SOMTParser{
     class GlobalOptions {
     public:
         // ENUM_LOGIC logic = UNKNOWN_LOGIC;
-        std::string logic = "UNKNOWN_LOGIC";
+        // Default to ALL: an input without (set-logic ...) should still be
+        // parsed with every theory available rather than under an unknown logic.
+        std::string logic = "ALL";
         bool check_sat = false;
         bool get_assertions = false;
         bool get_assignment = false;
@@ -81,6 +83,12 @@ namespace SOMTParser{
         // fp.roundToIntegral without RM; non-standard operator spellings like fp.=;
         // flat (to_fp eb sb x) without indexed head). Default false keeps backward compatibility.
         bool strict_smtlib_fp = false;
+
+        // When true, term annotations -- (! <term> :pattern (...) :qid q ...) --
+        // are kept as NT_ATTRIBUTE nodes instead of being parsed and dropped, so
+        // printing round-trips quantifier triggers. Off by default because
+        // consumers that walk assertion trees do not expect the extra node.
+        bool preserve_annotations = false;
 
         // Selected operators that must remain explicit in the DAG even when
         // their arguments are ground. This supports source-structure analyses
@@ -197,7 +205,10 @@ namespace SOMTParser{
                     logic = logic_name;
                     return true;
                 } else {
-                    logic = "UNKNOWN_LOGIC";
+                    // An unrecognised logic name (a newer standard logic, or a
+                    // solver-specific one) should not disable theories; fall
+                    // back to ALL and report the name as unrecognised.
+                    logic = "ALL";
                     return false;
                 }
         }
@@ -221,6 +232,9 @@ namespace SOMTParser{
             }
             else if(key == "strict_smtlib_fp"){
                 setStrictSmtlib(value == "true");
+            }
+            else if(key == "preserve_annotations"){
+                setPreserveAnnotations(value == "true");
             }
         }
 
@@ -284,6 +298,9 @@ namespace SOMTParser{
         void setStrictSmtlib(bool strict) { strict_smtlib_fp = strict; }
         bool getStrictSmtlib() const { return strict_smtlib_fp; }
 
+        void setPreserveAnnotations(bool preserve) { preserve_annotations = preserve; }
+        bool getPreserveAnnotations() const { return preserve_annotations; }
+
         void preserveOperator(NODE_KIND kind) { preserved_operators.insert(kind); }
         void preserveOperators(std::initializer_list<NODE_KIND> kinds) {
             preserved_operators.insert(kinds.begin(), kinds.end());
@@ -311,7 +328,7 @@ namespace SOMTParser{
             // Logic setting
             result += "1. Logic\n";
             result += "   Option: logic\n";
-            result += "   Default: UNKNOWN_LOGIC\n";
+            result += "   Default: ALL\n";
             result += "   Current: " + logic + "\n";
             result += "   Description: The SMT-LIB2 logic to use for parsing and reasoning.\n";
             result += "                Determines which theories and quantifiers are allowed.\n\n";
@@ -369,8 +386,18 @@ namespace SOMTParser{
             result += "                (to_fp eb sb x) calls. When false (default), lenient extensions are accepted\n";
             result += "                and unary fp.sqrt is canonicalized to (fp.sqrt RNE x) in the IR.\n\n";
             
+            result += "8. Preserve term annotations\n";
+            result += "   Option: preserve_annotations (set-option / GlobalOptions::setPreserveAnnotations)\n";
+            result += "   Default: false\n";
+            result += "   Current: " + std::string(preserve_annotations ? "true" : "false") + "\n";
+            result += "   Description: When true, (! <term> :pattern (...) :no-pattern t :weight n :qid q)\n";
+            result += "                annotations are kept in the AST and printed back, so quantifier\n";
+            result += "                triggers survive a parse/print round trip. When false (default),\n";
+            result += "                annotations are parsed and discarded as before. :named is recorded\n";
+            result += "                for unsat cores in either mode.\n\n";
+
             // Command flags
-            result += "8. Command Flags\n";
+            result += "9. Command Flags\n";
             result += "   check_sat: " + std::string(check_sat ? "true" : "false") + "\n";
             result += "   get_assertions: " + std::string(get_assertions ? "true" : "false") + "\n";
             result += "   get_assignment: " + std::string(get_assignment ? "true" : "false") + "\n";

--- a/include/somtparser/core/util.h
+++ b/include/somtparser/core/util.h
@@ -127,6 +127,21 @@ namespace SOMTParser{
         static std::string bvRotateRight(const std::string& bv, const Integer& n);
 
         static bool bvComp(const std::string& bv1, const std::string& bv2, const NODE_KIND& kind);
+
+        // Bit-pattern predicates, useful for rewriting guards.
+        // Ported from the SMTStabilizer fork.
+        /** @brief True iff @p bv is 0111...1 (largest signed value of its width). */
+        static bool bvIsMaxSigned(const std::string& bv);
+        /** @brief True iff @p bv is 1000...0 (smallest signed value of its width). */
+        static bool bvIsMinSigned(const std::string& bv);
+        /** @brief True iff @p bv is 111...1 (largest unsigned value of its width). */
+        static bool bvIsMaxUnsigned(const std::string& bv);
+        /** @brief True iff @p bv is 111...1, i.e. -1 read as a signed value. */
+        static bool bvIsNegOne(const std::string& bv);
+        /** @brief Compare @p bv (unsigned) against @p u; returns -1, 0 or 1. */
+        static int bvCompareToUint(const std::string& bv, const uint64_t& u);
+        /** @brief Build the all-ones bitvector literal of width @p n. */
+        static std::string mkOnes(const Integer& n);
     };
 
     // Floating point utilities
@@ -289,6 +304,11 @@ namespace SOMTParser{
         static std::string strToLower(const std::string& s);
         static std::string strToUpper(const std::string& s);
         static std::string strRev(const std::string& s);
+        /**
+         * @brief Strip one layer of surrounding double quotes, if present.
+         *        Ported from the SMTStabilizer fork.
+         */
+        static std::string strUnquote(const std::string& s);
     };
 
     /**

--- a/include/somtparser/frontend/parser.h
+++ b/include/somtparser/frontend/parser.h
@@ -60,7 +60,10 @@ namespace SOMTParser{
     };
 
     enum class KEYWORD{
-        KW_ID, KW_WEIGHT, KW_COMP, KW_EPSILON, KW_M, KW_OPT_KIND, KW_NAMED , KW_NULL
+        KW_ID, KW_WEIGHT, KW_COMP, KW_EPSILON, KW_M, KW_OPT_KIND, KW_NAMED,
+        // Quantifier annotations — ported from the SMTStabilizer fork.
+        KW_PATTERN, KW_NO_PATTERN, KW_QID, KW_SKOLEMID, KW_LBLPOS, KW_LBLNEG,
+        KW_NULL
     };
 
     enum class CMD_TYPE {
@@ -2512,7 +2515,23 @@ namespace SOMTParser{
          * @return Integer to bitvector conversion node (to_bv(param, width))
          */
         std::shared_ptr<DAGNode> mkIntToBv(std::shared_ptr<DAGNode> param, std::shared_ptr<DAGNode> width); // to_bv(param, width)
-        
+
+        /**
+         * @brief Create an unsigned bitvector-to-integer node (SMT-LIB 2.7 ubv_to_int)
+         *
+         * @param param Bitvector parameter
+         * @return ubv_to_int(param)
+         */
+        std::shared_ptr<DAGNode> mkUbvToInt(std::shared_ptr<DAGNode> param);
+
+        /**
+         * @brief Create a signed bitvector-to-integer node (SMT-LIB 2.7 sbv_to_int)
+         *
+         * @param param Bitvector parameter
+         * @return sbv_to_int(param)
+         */
+        std::shared_ptr<DAGNode> mkSbvToInt(std::shared_ptr<DAGNode> param);
+
         // FLOATING POINT COMMON OPERATORS
         /**
          * @brief Create a floating-point addition node
@@ -2804,7 +2823,44 @@ namespace SOMTParser{
          * @return Array store node (l[r] = v)
          */
         std::shared_ptr<DAGNode> mkStore(std::shared_ptr<DAGNode> l, std::shared_ptr<DAGNode> r, std::shared_ptr<DAGNode> v); // l[r] = v
-        
+
+        // TERM ANNOTATIONS
+        /** @brief Create a :pattern annotation node holding the trigger terms */
+        std::shared_ptr<DAGNode> mkPattern(const std::vector<std::shared_ptr<DAGNode>> &params);
+        /** @brief Create a :no-pattern annotation node */
+        std::shared_ptr<DAGNode> mkNoPattern(std::shared_ptr<DAGNode> param);
+        /** @brief Create a :weight annotation node */
+        std::shared_ptr<DAGNode> mkWeight(std::shared_ptr<DAGNode> weight);
+        /** @brief Create a :qid annotation node */
+        std::shared_ptr<DAGNode> mkQid(const std::string &qid);
+        /**
+         * @brief Wrap @p term in (! <term> <annotations>...); returns @p term unchanged
+         *        when there are no annotations.
+         */
+        std::shared_ptr<DAGNode> mkAttribute(std::shared_ptr<DAGNode> term, const std::vector<std::shared_ptr<DAGNode>> &annotations);
+
+        // TUPLE OPERATORS
+        /**
+         * @brief Create a tuple constructor node (tuple t1 ... tn); nullary yields tuple.unit
+         */
+        std::shared_ptr<DAGNode> mkTuple(const std::vector<std::shared_ptr<DAGNode>> &params);
+        /**
+         * @brief Create a tuple projection node ((_ tuple.select i) t)
+         */
+        std::shared_ptr<DAGNode> mkTupleSelect(std::shared_ptr<DAGNode> tuple, std::shared_ptr<DAGNode> index);
+        /**
+         * @brief Create a functional tuple update node ((_ tuple.update i) t v)
+         */
+        std::shared_ptr<DAGNode> mkTupleUpdate(std::shared_ptr<DAGNode> tuple, std::shared_ptr<DAGNode> index, std::shared_ptr<DAGNode> value);
+        /**
+         * @brief Create a tuple projection node ((_ tuple.project i1 ... ik) t)
+         */
+        std::shared_ptr<DAGNode> mkTupleProject(std::shared_ptr<DAGNode> tuple, const std::vector<std::shared_ptr<DAGNode>> &indices);
+        /**
+         * @brief Create a datatype update node ((_ update <selector>) t v)
+         */
+        std::shared_ptr<DAGNode> mkDtUpdate(const std::string &selector, std::shared_ptr<DAGNode> dt, std::shared_ptr<DAGNode> value);
+
         // STRINGS COMMON OPERATORS
         /**
          * @brief Create a string length node

--- a/include/somtparser/frontend/parser.h
+++ b/include/somtparser/frontend/parser.h
@@ -413,6 +413,11 @@ namespace SOMTParser{
         * @return set option value
         */
         void setOption(const std::string& key, const std::string& value);
+        // A string literal must be treated as a string, not as a bool. Without
+        // this overload setOption("keep_let", "false") selects the bool
+        // overload -- pointer-to-bool is a standard conversion and so beats the
+        // user-defined conversion to std::string -- and silently sets true.
+        void setOption(const std::string& key, const char* value);
         void setOption(const std::string& key, const int& value);
         void setOption(const std::string& key, const double& value);
         void setOption(const std::string& key, const bool& value);

--- a/include/somtparser/ir/number.h
+++ b/include/somtparser/ir/number.h
@@ -49,6 +49,9 @@ namespace SOMTParser {
             HighPrecisionInteger(int i);
             HighPrecisionInteger(long i);
             HighPrecisionInteger(unsigned long i);
+            // On LLP64 (Windows) unsigned long is 32-bit, so a 64-bit unsigned
+            // value would otherwise narrow. Ported from the SMTStabilizer fork.
+            HighPrecisionInteger(unsigned long long i);
             HighPrecisionInteger(double d);
             HighPrecisionInteger(const std::string& s, int base = 10);
             HighPrecisionInteger(const char* s, int base = 10);
@@ -314,9 +317,12 @@ namespace SOMTParser {
             };
 
             // Constant
-            static Number ZERO;
-            static Number ONE;
-            static Number INFINITY;
+            // NOTE: `static Number ZERO/ONE/INFINITY;` used to be declared here.
+            // None of them had a definition or a single user, so any reference
+            // would have been a link error. INFINITY was worse than dead: it is
+            // a <cmath> macro, so a translation unit including <cmath> first
+            // silently turned the declaration into a function declaration.
+            // Use Number(0), Number(1) and Number::infinity() (below) instead.
             static Number pi(size_t precision = 128);
             static Number e(size_t precision = 128);
             static Number phi(size_t precision = 128);

--- a/include/somtparser/ir/sort.h
+++ b/include/somtparser/ir/sort.h
@@ -41,7 +41,9 @@ namespace SOMTParser{
     
     // supported const/variable types
     enum class SORT_KIND {
-        SK_NULL=0, SK_UNKNOWN, SK_BOOL, SK_INT, SK_REAL, SK_BV, SK_FP, SK_STR, SK_ARRAY, SK_DATATYPE, SK_SET, SK_RELATION, SK_BAG, SK_SEQ, SK_UF, 
+        SK_NULL=0, SK_UNKNOWN, SK_BOOL, SK_INT, SK_REAL, SK_BV, SK_FP, SK_STR, SK_ARRAY, SK_DATATYPE, SK_SET, SK_RELATION, SK_BAG, SK_SEQ,
+        SK_TUPLE, // (Tuple T1 ... Tn) — ported from the SMTStabilizer fork
+        SK_UF,
         SK_REG, // regular expression
         SK_EXT, // extended real
         SK_RAT, // rational number
@@ -102,6 +104,12 @@ namespace SOMTParser{
         bool isRelation() const { return kind == SORT_KIND::SK_RELATION; }
         bool isBag() const { return kind == SORT_KIND::SK_BAG; }
         bool isSeq() const { return kind == SORT_KIND::SK_SEQ; }
+        bool isTuple() const { return kind == SORT_KIND::SK_TUPLE; }
+        size_t getChildrenSize() const { return children.size(); }
+        std::shared_ptr<Sort> getChild(size_t i) const {
+            condAssert(i < children.size(), "Sort::getChild: index out of range");
+            return children[i];
+        }
         bool isUF() const { return kind == SORT_KIND::SK_UF; }
         bool isNat() const { return kind == SORT_KIND::SK_NAT; }
         bool isRand() const { return kind == SORT_KIND::SK_RAND; }
@@ -215,8 +223,18 @@ namespace SOMTParser{
                 case SORT_KIND::SK_RELATION: return "Relation";
                 case SORT_KIND::SK_BAG: return "Bag";
                 case SORT_KIND::SK_SEQ: return "Sequence";
+                case SORT_KIND::SK_TUPLE: {
+                    // (Tuple T1 ... Tn); the nullary tuple sort is UnitTuple.
+                    if(children.empty()) return "UnitTuple";
+                    std::string s = "(Tuple";
+                    for(const auto& ch : children) s += " " + ch->toString();
+                    return s + ")";
+                }
                 case SORT_KIND::SK_UF: return "UF";
-                case SORT_KIND::SK_REG: return "(RegEx String)";
+                // The regular-expression sort is spelled RegLan in SMT-LIB;
+                // base_parser reads that spelling, so printing anything else
+                // made our own output unparsable by us.
+                case SORT_KIND::SK_REG: return "RegLan";
                 case SORT_KIND::SK_EXT: return "ExtReal";
                 case SORT_KIND::SK_NAT: return "Natural";
                 case SORT_KIND::SK_RAND: return "Random";
@@ -328,6 +346,8 @@ namespace SOMTParser{
             std::shared_ptr<Sort> createBVSort(size_t width);
             std::shared_ptr<Sort> createFPSort(size_t exp, size_t sig);
             std::shared_ptr<Sort> createArraySort(std::shared_ptr<Sort> index, std::shared_ptr<Sort> elem);
+            /** (Tuple T1 ... Tn); an empty field list yields the unit tuple sort. */
+            std::shared_ptr<Sort> createTupleSort(const std::vector<std::shared_ptr<Sort>>& fields);
             std::shared_ptr<Sort> createDatatypeSort(const std::string& name,
                 const std::vector<Sort::DtConstructor>& constructors);
             std::shared_ptr<Sort> createSortDec(const std::string& name, size_t arity);

--- a/src/core/kind.cpp
+++ b/src/core/kind.cpp
@@ -335,6 +335,16 @@ namespace SOMTParser{
             return "bv2nat";
         case NODE_KIND::NT_NAT_TO_BV:
             return "nat2bv";
+        // These two had no case at all, so they fell through to the
+        // "UNKNOWN_KIND" default and printed as (UNKNOWN_KIND x).
+        case NODE_KIND::NT_BV_TO_INT:
+            return "bv2int";
+        case NODE_KIND::NT_INT_TO_BV:
+            return "int2bv";
+        case NODE_KIND::NT_UBV_TO_INT:
+            return "ubv_to_int";
+        case NODE_KIND::NT_SBV_TO_INT:
+            return "sbv_to_int";
         // FLOATING POINT COMMON OPERATORS
         case NODE_KIND::NT_FP_ADD:
             return "fp.add";
@@ -405,6 +415,32 @@ namespace SOMTParser{
             return "select";
         case NODE_KIND::NT_STORE:
             return "store";
+        // DATATYPE / TUPLE / ANNOTATION operators — ported from the
+        // SMTStabilizer fork.
+        case NODE_KIND::NT_DT_TESTER:
+            return "is";
+        case NODE_KIND::NT_DT_UPDATER:
+            return "update";
+        case NODE_KIND::NT_TUPLE_CONSTRUCTOR:
+            return "tuple";
+        case NODE_KIND::NT_TUPLE_UNIT:
+            return "tuple.unit";
+        case NODE_KIND::NT_TUPLE_SELECT:
+            return "tuple.select";
+        case NODE_KIND::NT_TUPLE_UPDATE:
+            return "tuple.update";
+        case NODE_KIND::NT_TUPLE_PROJECT:
+            return "tuple.project";
+        case NODE_KIND::NT_ATTRIBUTE:
+            return "!";
+        case NODE_KIND::NT_PATTERN:
+            return ":pattern";
+        case NODE_KIND::NT_NO_PATTERN:
+            return ":no-pattern";
+        case NODE_KIND::NT_WEIGHT:
+            return ":weight";
+        case NODE_KIND::NT_QID:
+            return ":qid";
         // STRINGS COMMON OPERATORS
         case NODE_KIND::NT_STR_LEN:
             return "str.len";
@@ -720,6 +756,9 @@ namespace SOMTParser{
         "sinh", "cosh", "tanh", "sech", "csch", "coth",
         "asinh", "arcsinh", "acosh", "arccosh", "atanh", "arctanh",
         "asech", "acsch", "arccsch", "acoth", "arccoth",
+        // "tuple" is a plausible user symbol, so let a declared function of that
+        // name win over the tuple-theory constructor.
+        "tuple",
     };
 
     bool builtinOperMayBeShadowedByUserFun(const std::string& s) {

--- a/src/core/util.cpp
+++ b/src/core/util.cpp
@@ -1030,6 +1030,45 @@ namespace SOMTParser{
         }
         return res;
     }
+    // Bit-pattern predicates — ported from the SMTStabilizer fork.
+    bool BitVectorUtils::bvIsMaxSigned(const std::string& bv){
+        condAssert(bv.size() > 2 && bv[0] == '#' && bv[1] == 'b', "BitVectorUtils::bvIsMaxSigned: invalid bitvector");
+        if(bv[2] != '0') return false;
+        return std::all_of(bv.begin() + 3, bv.end(), [](char c){ return c == '1'; });
+    }
+    bool BitVectorUtils::bvIsMinSigned(const std::string& bv){
+        condAssert(bv.size() > 2 && bv[0] == '#' && bv[1] == 'b', "BitVectorUtils::bvIsMinSigned: invalid bitvector");
+        if(bv[2] != '1') return false;
+        return std::all_of(bv.begin() + 3, bv.end(), [](char c){ return c == '0'; });
+    }
+    bool BitVectorUtils::bvIsMaxUnsigned(const std::string& bv){
+        condAssert(bv.size() > 2 && bv[0] == '#' && bv[1] == 'b', "BitVectorUtils::bvIsMaxUnsigned: invalid bitvector");
+        return std::all_of(bv.begin() + 2, bv.end(), [](char c){ return c == '1'; });
+    }
+    bool BitVectorUtils::bvIsNegOne(const std::string& bv){
+        // -1 and the maximum unsigned value share the all-ones bit pattern.
+        return bvIsMaxUnsigned(bv);
+    }
+    int BitVectorUtils::bvCompareToUint(const std::string& bv, const uint64_t& u){
+        condAssert(bv.size() > 2 && bv[0] == '#' && bv[1] == 'b', "BitVectorUtils::bvCompareToUint: invalid bitvector");
+        const size_t width = bv.size() - 2;
+        // Any set bit above bit 63 already exceeds every uint64_t value.
+        if(width > 64){
+            for(size_t i = 2; i + 64 < bv.size(); ++i){
+                if(bv[i] == '1') return 1;
+            }
+        }
+        uint64_t value = 0;
+        for(size_t i = (width > 64 ? bv.size() - 64 : 2); i < bv.size(); ++i){
+            value = (value << 1) | (bv[i] == '1' ? 1u : 0u);
+        }
+        if(value < u) return -1;
+        if(value > u) return 1;
+        return 0;
+    }
+    std::string BitVectorUtils::mkOnes(const Integer& n){
+        return "#b" + std::string(n.toULong(), '1');
+    }
     std::string BitVectorUtils::natToBv(const Integer& i, const Integer& n){
         std::string res = "#b";
         std::string bin = i.toString(2);
@@ -1354,6 +1393,12 @@ namespace SOMTParser{
     std::string StringUtils::strRev(const std::string& s){
         std::string res = (s[0] == '"' && s[s.length()-1] == '"') ? s.substr(1, s.length()-2) : s;
         return "\"" + std::string(res.rbegin(), res.rend()) + "\"";
+    }
+
+    // Ported from the SMTStabilizer fork.
+    std::string StringUtils::strUnquote(const std::string& s){
+        if(s.size() >= 2 && s.front() == '"' && s.back() == '"') return s.substr(1, s.size() - 2);
+        return s;
     }
 
     // ─── RegexUtils ─────────────────────────────────────────────────────────────

--- a/src/frontend/base_parser.cpp
+++ b/src/frontend/base_parser.cpp
@@ -248,6 +248,9 @@ namespace SOMTParser{
 	void Parser::setOption(const std::string& key, const std::string& value){
 		getOptions()->setOption(key, value);
 	}
+	void Parser::setOption(const std::string& key, const char* value){
+		getOptions()->setOption(key, value ? std::string(value) : std::string());
+	}
 	void Parser::setOption(const std::string& key, const int& value){
 		getOptions()->setOption(key, std::to_string(value));
 	}

--- a/src/frontend/base_parser.cpp
+++ b/src/frontend/base_parser.cpp
@@ -765,27 +765,42 @@ namespace SOMTParser{
 	bool Parser::parseSmtlib2File(const std::string filename) {
 
 		/*
-		load file
+		load file -- an empty name or "-" reads the script from stdin, so the
+		parser can be used in a pipeline. Ported from the SMTStabilizer fork.
 		*/
-		std::ifstream fin(filename, std::ifstream::binary);
+		delete[] buffer;
+		buffer = nullptr;
 
-		if (!fin) {
-			std::cout << "error: Cannot open file \"" << filename << "\"." << std::endl;
-			return false;
+		if (filename.empty() || filename == "-") {
+			std::string content((std::istreambuf_iterator<char>(std::cin)),
+			                    std::istreambuf_iterator<char>());
+			buflen = (long)content.size();
+			buffer = new char[buflen + 1];
+			if (buflen > 0) std::memcpy(buffer, content.data(), (size_t)buflen);
+			buffer[buflen] = 0;
+			source_name_ = "<stdin>";
 		}
+		else {
+			std::ifstream fin(filename, std::ifstream::binary);
 
-		fin.seekg(0, std::ios::end);
-		buflen = (long)fin.tellg();
-		fin.seekg(0, std::ios::beg);
+			if (!fin) {
+				std::cout << "error: Cannot open file \"" << filename << "\"." << std::endl;
+				return false;
+			}
 
-		buffer = new char[buflen + 1];
-		fin.read(buffer, buflen);
-		buffer[buflen] = 0;
+			fin.seekg(0, std::ios::end);
+			buflen = (long)fin.tellg();
+			fin.seekg(0, std::ios::beg);
+
+			buffer = new char[buflen + 1];
+			fin.read(buffer, buflen);
+			buffer[buflen] = 0;
+			source_name_ = filename;
+
+			fin.close();
+		}
 		source_text_.assign(buffer, static_cast<size_t>(buflen));
-		source_name_ = filename;
 		next_command_index_ = 0;
-
-		fin.close();
 
 		/*
 		parse command
@@ -973,6 +988,25 @@ namespace SOMTParser{
 		}
 		else if(key == ":weight"){
 			return KEYWORD::KW_WEIGHT;
+		}
+		// Quantifier annotations — ported from the SMTStabilizer fork.
+		else if(key == ":pattern"){
+			return KEYWORD::KW_PATTERN;
+		}
+		else if(key == ":no-pattern"){
+			return KEYWORD::KW_NO_PATTERN;
+		}
+		else if(key == ":qid"){
+			return KEYWORD::KW_QID;
+		}
+		else if(key == ":skolemid"){
+			return KEYWORD::KW_SKOLEMID;
+		}
+		else if(key == ":lblpos"){
+			return KEYWORD::KW_LBLPOS;
+		}
+		else if(key == ":lblneg"){
+			return KEYWORD::KW_LBLNEG;
 		}
 		else if (key == ":comp"){
 			return KEYWORD::KW_COMP;
@@ -1909,6 +1943,11 @@ namespace SOMTParser{
 			if (basic_it != BASIC_SORTS.end()) {
 				return basic_it->second;
 			}
+			// The nullary tuple sort is spelled UnitTuple; it needs the sort
+			// manager, so it cannot live in the static BASIC_SORTS table.
+			else if (s == "UnitTuple") {
+				return getSortManager()->createTupleSort({});
+			}
 			// then check the user-defined type
 			else {
 				std::shared_ptr<Sort> usort = getSymbolManager()->resolveSort(s);
@@ -1936,6 +1975,16 @@ namespace SOMTParser{
 				sort = getSortManager()->createArraySort(sortS, sortT);
 				getSymbolManager()->registerSort(sort_key_name, sort);
 			}
+		}
+		else if(s == "Tuple"){
+			// (Tuple T1 ... Tn) — ported from the SMTStabilizer fork.
+			std::vector<std::shared_ptr<Sort>> fields;
+			scanToNextSymbol();
+			while(*bufptr && *bufptr != ')'){
+				fields.emplace_back(parseSort());
+				scanToNextSymbol();
+			}
+			sort = getSortManager()->createTupleSort(fields);
 		}
 		else if(s == "Datatype"){}
 		else if(s == "Set"){}

--- a/src/frontend/expr_parser.cpp
+++ b/src/frontend/expr_parser.cpp
@@ -31,6 +31,12 @@
 
 namespace SOMTParser{
 
+    // Internal marker used to route ((_ update <selector>) t v) through the
+    // regular operator path while carrying the selector name. The leading
+    // control character cannot appear in an SMT-LIB symbol, so this can never
+    // be confused with a user-declared function.
+    static constexpr const char* DT_UPDATE_PREFIX = "\x01update-";
+
     // State of the parser
     enum class FrameState {
         Start,
@@ -113,6 +119,19 @@ namespace SOMTParser{
                                 parseRpar();
                                 frame.headSymbol = "_";
                                 frame.second_symbol = "is-" + ctor;
+                                frame.state = FrameState::ProcessingParams;
+                                break;
+                            }
+                            // ((_ update <selector>) t v): like (_ is C), the
+                            // index is a selector *symbol* rather than a
+                            // numeral, so it cannot go through the generic
+                            // ParamFunc path (which parses indices as terms).
+                            // Ported from the SMTStabilizer fork.
+                            if(idx == "update"){
+                                std::string sel = getSymbol();
+                                parseRpar();
+                                frame.headSymbol = "_";
+                                frame.second_symbol = DT_UPDATE_PREFIX + sel;
                                 frame.state = FrameState::ProcessingParams;
                                 break;
                             }
@@ -402,6 +421,13 @@ namespace SOMTParser{
                         // parenthesised pattern lists.  Previously only :named
                         // was handled, so quantified benchmarks carrying
                         // :pattern (almost all of UFNIA/UFDT/...) failed to parse.
+                        // With preserve_annotations enabled the understood
+                        // annotations are kept as nodes so printing round-trips
+                        // triggers instead of silently dropping them (ported
+                        // from the SMTStabilizer fork); otherwise the original
+                        // skip-everything behaviour is retained.
+                        const bool keep_annots = getOptions()->getPreserveAnnotations();
+                        std::vector<std::shared_ptr<DAGNode>> annotations;
                         std::shared_ptr<DAGNode> formula = parseExpr();
                         scanToNextSymbol();
                         while(*bufptr && *bufptr != ')'){
@@ -416,6 +442,30 @@ namespace SOMTParser{
                                    && *bufptr != ':' && *bufptr != ')'){
                                     std::string name = getSymbol();
                                     context_.named_assertions[name] = formula;
+                                    scanToNextSymbol();
+                                }else if(keep_annots && kw == ":pattern" && *bufptr == '('){
+                                    parseLpar();
+                                    std::vector<std::shared_ptr<DAGNode>> patterns;
+                                    scanToNextSymbol();
+                                    while(*bufptr && *bufptr != ')'){
+                                        patterns.emplace_back(parseExpr());
+                                        scanToNextSymbol();
+                                    }
+                                    parseRpar();
+                                    annotations.emplace_back(mkPattern(patterns));
+                                    scanToNextSymbol();
+                                }else if(keep_annots && kw == ":no-pattern"
+                                         && *bufptr && *bufptr != ':' && *bufptr != ')'){
+                                    annotations.emplace_back(mkNoPattern(parseExpr()));
+                                    scanToNextSymbol();
+                                }else if(keep_annots && kw == ":weight"
+                                         && *bufptr && *bufptr != ':' && *bufptr != ')'){
+                                    annotations.emplace_back(mkWeight(parseExpr()));
+                                    scanToNextSymbol();
+                                }else if(keep_annots && kw == ":qid"
+                                         && *bufptr && *bufptr != ':' && *bufptr != ')'
+                                         && *bufptr != '('){
+                                    annotations.emplace_back(mkQid(getSymbol()));
                                     scanToNextSymbol();
                                 }else if(*bufptr == '('){
                                     // skip a balanced parenthesised value
@@ -434,6 +484,9 @@ namespace SOMTParser{
                                 getSymbol();  // unexpected token; make progress
                                 scanToNextSymbol();
                             }
+                        }
+                        if(!annotations.empty()){
+                            formula = mkAttribute(formula, annotations);
                         }
                         frame.result = formula;
                         parseRpar();
@@ -741,6 +794,11 @@ namespace SOMTParser{
 			return mkConstStr(s);
 		}
 		// no parameters
+		// tuple.unit is the nullary tuple constant, so it appears as a bare
+		// symbol rather than an application. Ported from the SMTStabilizer fork.
+		else if (s == "tuple.unit"){
+			return mkTuple({});
+		}
 		else if (s == "re.none"){
 			return mkRegNone();
 		}
@@ -789,6 +847,12 @@ namespace SOMTParser{
 	std::shared_ptr<DAGNode> Parser::parseOper(const std::string& s, const std::vector<std::shared_ptr<DAGNode>>& func_args, const std::vector<std::shared_ptr<DAGNode>> &oper_params, bool indexed_under_score){
 		TIME_FUNC();
 		auto func = getSymbolManager()->resolveFun(s);
+		// ((_ update <sel>) t v) arrives with the selector folded into the name
+		// under a marker prefix that cannot occur in an SMT-LIB symbol, so this
+		// can never collide with a user-declared function.
+		if(!func && s.rfind(DT_UPDATE_PREFIX, 0) == 0 && oper_params.size() == 2){
+			return mkDtUpdate(s.substr(std::string(DT_UPDATE_PREFIX).size()), oper_params[0], oper_params[1]);
+		}
 		// Datatype tester/constructor/selector applied here: the indexed tester
 		// form (_ is C) registers as a FuncDec named "is-C", and an applied
 		// constructor/selector also resolves as a FuncDec — applyFun would emit a
@@ -1097,8 +1161,20 @@ namespace SOMTParser{
                 condAssert(oper_params.size() == 1, "Invalid number of parameters for bv2nat");
                 return mkBvToNat(oper_params[0]);
             case NODE_KIND::NT_NAT_TO_BV:
+                // Both the indexed SMT-LIB form ((_ nat2bv m) t) — where the
+                // width arrives in func_args — and the flat (nat2bv t m) form.
+                // The indexed form used to abort on the 2-parameter assert.
+                if(func_args.size() == 1 && oper_params.size() == 1){
+                    return mkNatToBv(oper_params[0], func_args[0]);
+                }
                 condAssert(oper_params.size() == 2, "Invalid number of parameters for nat2bv");
                 return mkNatToBv(oper_params[0], oper_params[1]);
+            case NODE_KIND::NT_UBV_TO_INT:
+                condAssert(oper_params.size() == 1, "Invalid number of parameters for ubv_to_int");
+                return mkUbvToInt(oper_params[0]);
+            case NODE_KIND::NT_SBV_TO_INT:
+                condAssert(oper_params.size() == 1, "Invalid number of parameters for sbv_to_int");
+                return mkSbvToInt(oper_params[0]);
             case NODE_KIND::NT_INT_TO_BV:
                 condAssert(func_args.size() == 1, "Invalid number of arguments for int_to_bv");
                 condAssert(oper_params.size() == 1, "Invalid number of parameters for int_to_bv");
@@ -1297,6 +1373,25 @@ namespace SOMTParser{
             case NODE_KIND::NT_STORE:
                 condAssert(oper_params.size() == 3, "Invalid number of parameters for store");
                 return mkStore(oper_params[0], oper_params[1], oper_params[2]);
+            // TUPLE OPERATORS — ported from the SMTStabilizer fork. The
+            // select/update/project indices arrive as func_args because the
+            // operators are indexed: ((_ tuple.select i) t).
+            case NODE_KIND::NT_TUPLE_CONSTRUCTOR:
+                return mkTuple(oper_params);
+            case NODE_KIND::NT_TUPLE_UNIT:
+                condAssert(oper_params.empty(), "tuple.unit takes no parameters");
+                return mkTuple({});
+            case NODE_KIND::NT_TUPLE_SELECT:
+                condAssert(func_args.size() == 1, "Invalid number of arguments for tuple.select");
+                condAssert(oper_params.size() == 1, "Invalid number of parameters for tuple.select");
+                return mkTupleSelect(oper_params[0], func_args[0]);
+            case NODE_KIND::NT_TUPLE_UPDATE:
+                condAssert(func_args.size() == 1, "Invalid number of arguments for tuple.update");
+                condAssert(oper_params.size() == 2, "Invalid number of parameters for tuple.update");
+                return mkTupleUpdate(oper_params[0], func_args[0], oper_params[1]);
+            case NODE_KIND::NT_TUPLE_PROJECT:
+                condAssert(oper_params.size() == 1, "Invalid number of parameters for tuple.project");
+                return mkTupleProject(oper_params[0], func_args);
             case NODE_KIND::NT_ROOT_OBJ:
                 condAssert(oper_params.size() == 2, "root-obj requires exactly 2 parameters");
                 {

--- a/src/frontend/op_parser.cpp
+++ b/src/frontend/op_parser.cpp
@@ -72,6 +72,22 @@ namespace SOMTParser{
             case NODE_KIND::NT_DISTINCT:
             case NODE_KIND::NT_MAX:
             case NODE_KIND::NT_MIN:
+            // Additional symmetric operators, from the SMTStabilizer fork's
+            // list.  Its NT_FORALL/NT_EXISTS/NT_FP_ADD/NT_FP_MUL entries are
+            // deliberately omitted: those carry a non-operand first child (the
+            // bound-variable list, resp. the rounding mode), and sortParams
+            // here reorders *all* operands.
+            case NODE_KIND::NT_BV_NAND:
+            case NODE_KIND::NT_BV_NOR:
+            case NODE_KIND::NT_BV_XNOR:
+            case NODE_KIND::NT_BV_COMP:
+            case NODE_KIND::NT_BV_UADDO:
+            case NODE_KIND::NT_BV_SADDO:
+            case NODE_KIND::NT_BV_UMULO:
+            case NODE_KIND::NT_BV_SMULO:
+            case NODE_KIND::NT_FP_EQ:
+            case NODE_KIND::NT_FP_MIN:
+            case NODE_KIND::NT_FP_MAX:
                 return true;
             default:
                 return false;
@@ -164,8 +180,12 @@ namespace SOMTParser{
             params_with_hash.emplace_back(param, param->hashCode());
         }
         
-        // sort by hash code
-        std::sort(params_with_hash.begin(), params_with_hash.end(), compareByHash);
+        // Sort by hash code. stable_sort, not sort: hash collisions must fall
+        // back to input order, otherwise operands that hash alike come out in
+        // an unspecified order and the AST stops being reproducible. (The
+        // SMTStabilizer fork breaks such ties by comparing shared_ptr values,
+        // which orders by heap address and is not reproducible across runs.)
+        std::stable_sort(params_with_hash.begin(), params_with_hash.end(), compareByHash);
         
         // extract sorted nodes
         for(size_t i = 0; i < params_with_hash.size(); i++) {
@@ -3164,6 +3184,28 @@ namespace SOMTParser{
         std::shared_ptr<Sort> new_sort = getSortManager()->createBVSort(toInt(size).toULong());
         return mkOper(new_sort, NODE_KIND::NT_INT_TO_BV, param, size);
     }
+    /*
+    (ubv_to_int Bv), return Int -- SMT-LIB 2.7 spelling of the unsigned
+    bitvector-to-integer conversion. Ported from the SMTStabilizer fork.
+    */
+    std::shared_ptr<DAGNode> Parser::mkUbvToInt(std::shared_ptr<DAGNode> param){
+        if(!isBvParam(param)) {
+            err_all(ERROR_TYPE::ERR_TYPE_MIS, "Type mismatch in ubv_to_int", line_number);
+            return mkUnknown();
+        }
+        return mkOper(SortManager::INT_SORT, NODE_KIND::NT_UBV_TO_INT, param);
+    }
+    /*
+    (sbv_to_int Bv), return Int -- SMT-LIB 2.7 signed counterpart.
+    Ported from the SMTStabilizer fork.
+    */
+    std::shared_ptr<DAGNode> Parser::mkSbvToInt(std::shared_ptr<DAGNode> param){
+        if(!isBvParam(param)) {
+            err_all(ERROR_TYPE::ERR_TYPE_MIS, "Type mismatch in sbv_to_int", line_number);
+            return mkUnknown();
+        }
+        return mkOper(SortManager::INT_SORT, NODE_KIND::NT_SBV_TO_INT, param);
+    }
 
     // FLOATING POINT COMMON OPERATORS
     /*
@@ -3840,6 +3882,119 @@ namespace SOMTParser{
         // Apply array simplification to normalize store chain
         return simplifyArray(store_node);
     }
+    // TERM ANNOTATIONS — ported from the SMTStabilizer fork.
+    // These are structural wrappers, so they bypass mkOper (and therefore
+    // simplification): folding an annotation away is exactly what we are trying
+    // to avoid.
+    std::shared_ptr<DAGNode> Parser::mkPattern(const std::vector<std::shared_ptr<DAGNode>> &params){
+        return getNodeManager()->createNode(SortManager::NULL_SORT, NODE_KIND::NT_PATTERN, ":pattern", params);
+    }
+    std::shared_ptr<DAGNode> Parser::mkNoPattern(std::shared_ptr<DAGNode> param){
+        return getNodeManager()->createNode(SortManager::NULL_SORT, NODE_KIND::NT_NO_PATTERN, ":no-pattern", {param});
+    }
+    std::shared_ptr<DAGNode> Parser::mkWeight(std::shared_ptr<DAGNode> weight){
+        return getNodeManager()->createNode(SortManager::NULL_SORT, NODE_KIND::NT_WEIGHT, ":weight", {weight});
+    }
+    std::shared_ptr<DAGNode> Parser::mkQid(const std::string &qid){
+        return getNodeManager()->createNode(SortManager::NULL_SORT, NODE_KIND::NT_QID, qid);
+    }
+    std::shared_ptr<DAGNode> Parser::mkAttribute(std::shared_ptr<DAGNode> term, const std::vector<std::shared_ptr<DAGNode>> &annotations){
+        if(annotations.empty()) return term;
+        std::vector<std::shared_ptr<DAGNode>> children{term};
+        children.insert(children.end(), annotations.begin(), annotations.end());
+        return getNodeManager()->createNode(term->getSort(), NODE_KIND::NT_ATTRIBUTE, "!", children);
+    }
+
+    // TUPLE OPERATORS — ported from the SMTStabilizer fork.
+    /*
+    (tuple t1 ... tn), return (Tuple T1 ... Tn); the nullary case is tuple.unit.
+    */
+    std::shared_ptr<DAGNode> Parser::mkTuple(const std::vector<std::shared_ptr<DAGNode>> &params){
+        std::vector<std::shared_ptr<Sort>> field_sorts;
+        field_sorts.reserve(params.size());
+        for(const auto& p : params){
+            if(p->isErr()) return p;
+            field_sorts.emplace_back(p->getSort());
+        }
+        std::shared_ptr<Sort> sort = getSortManager()->createTupleSort(field_sorts);
+        // tuple.unit is nullary, and mkOper rejects an empty parameter list.
+        if(params.empty()) return getNodeManager()->createNode(sort, NODE_KIND::NT_TUPLE_UNIT, "tuple.unit");
+        return mkOper(sort, NODE_KIND::NT_TUPLE_CONSTRUCTOR, params);
+    }
+    /*
+    ((_ tuple.select i) t), return Ti
+    */
+    std::shared_ptr<DAGNode> Parser::mkTupleSelect(std::shared_ptr<DAGNode> tuple, std::shared_ptr<DAGNode> index){
+        if(tuple->isErr()) return tuple;
+        if(index->isErr()) return index;
+        if(!tuple->getSort() || !tuple->getSort()->isTuple()) {
+            err_all(ERROR_TYPE::ERR_TYPE_MIS, "Type mismatch in tuple.select: first argument is not a tuple", line_number);
+            return mkUnknown();
+        }
+        const size_t i = toInt(index).toULong();
+        if(i >= tuple->getSort()->getChildrenSize()) {
+            err_all(ERROR_TYPE::ERR_TYPE_MIS, "tuple.select index out of range", line_number);
+            return mkUnknown();
+        }
+        return mkOper(tuple->getSort()->getChild(i), NODE_KIND::NT_TUPLE_SELECT, tuple, index);
+    }
+    /*
+    ((_ tuple.update i) t v), return the tuple sort of t
+    */
+    std::shared_ptr<DAGNode> Parser::mkTupleUpdate(std::shared_ptr<DAGNode> tuple, std::shared_ptr<DAGNode> index, std::shared_ptr<DAGNode> value){
+        if(tuple->isErr()) return tuple;
+        if(index->isErr()) return index;
+        if(value->isErr()) return value;
+        if(!tuple->getSort() || !tuple->getSort()->isTuple()) {
+            err_all(ERROR_TYPE::ERR_TYPE_MIS, "Type mismatch in tuple.update: first argument is not a tuple", line_number);
+            return mkUnknown();
+        }
+        const size_t i = toInt(index).toULong();
+        if(i >= tuple->getSort()->getChildrenSize()) {
+            err_all(ERROR_TYPE::ERR_TYPE_MIS, "tuple.update index out of range", line_number);
+            return mkUnknown();
+        }
+        return mkOper(tuple->getSort(), NODE_KIND::NT_TUPLE_UPDATE, tuple, index, value);
+    }
+    /*
+    ((_ tuple.project i1 ... ik) t), return (Tuple Ti1 ... Tik)
+    */
+    std::shared_ptr<DAGNode> Parser::mkTupleProject(std::shared_ptr<DAGNode> tuple, const std::vector<std::shared_ptr<DAGNode>> &indices){
+        if(tuple->isErr()) return tuple;
+        if(!tuple->getSort() || !tuple->getSort()->isTuple()) {
+            err_all(ERROR_TYPE::ERR_TYPE_MIS, "Type mismatch in tuple.project: argument is not a tuple", line_number);
+            return mkUnknown();
+        }
+        std::vector<std::shared_ptr<Sort>> field_sorts;
+        std::vector<std::shared_ptr<DAGNode>> params{tuple};
+        field_sorts.reserve(indices.size());
+        params.reserve(indices.size() + 1);
+        for(const auto& idx : indices){
+            if(idx->isErr()) return idx;
+            const size_t i = toInt(idx).toULong();
+            if(i >= tuple->getSort()->getChildrenSize()) {
+                err_all(ERROR_TYPE::ERR_TYPE_MIS, "tuple.project index out of range", line_number);
+                return mkUnknown();
+            }
+            field_sorts.emplace_back(tuple->getSort()->getChild(i));
+            params.emplace_back(idx);
+        }
+        return mkOper(getSortManager()->createTupleSort(field_sorts), NODE_KIND::NT_TUPLE_PROJECT, params);
+    }
+    /*
+    ((_ update <selector>) t v), return the datatype sort of t.
+    Ported from the SMTStabilizer fork.
+    */
+    std::shared_ptr<DAGNode> Parser::mkDtUpdate(const std::string &selector, std::shared_ptr<DAGNode> dt, std::shared_ptr<DAGNode> value){
+        if(dt->isErr()) return dt;
+        if(value->isErr()) return value;
+        if(!dt->getSort() || !dt->getSort()->isDatatype() || !dt->getSort()->hasDtSelector(selector)) {
+            err_all(ERROR_TYPE::ERR_TYPE_MIS, "Type mismatch in datatype update: no such selector", line_number);
+            return mkUnknown();
+        }
+        return getNodeManager()->createNode(dt->getSort(), NODE_KIND::NT_DT_UPDATER, selector, {dt, value});
+    }
+
     // STRINGS COMMON OPERATORS
     /*
     (str.len Str), return Nat

--- a/src/ir/dag.cpp
+++ b/src/ir/dag.cpp
@@ -387,7 +387,12 @@ namespace SOMTParser{
             case NODE_KIND::NT_BV_ZERO_EXT:
             case NODE_KIND::NT_BV_SIGN_EXT:
             case NODE_KIND::NT_BV_ROTATE_LEFT:
-            case NODE_KIND::NT_BV_ROTATE_RIGHT: {
+            case NODE_KIND::NT_BV_ROTATE_RIGHT:
+            // int2bv/nat2bv are indexed too — without these two they fell to
+            // the generic path and printed as (int2bv x 8) instead of
+            // ((_ int2bv 8) x).  Ported from the SMTStabilizer fork.
+            case NODE_KIND::NT_INT_TO_BV:
+            case NODE_KIND::NT_NAT_TO_BV: {
                 auto child0 = node->getChild(0).get();
                 auto child1 = node->getChild(1).get();
 
@@ -645,17 +650,116 @@ namespace SOMTParser{
                 break;
             }
             case NODE_KIND::NT_DT_TESTER: {
-                // Tester application: (is-CtorName arg); bare symbol if no arg (same as ctor)
+                // Tester application.  SMT-LIB 2.6 spells this ((_ is C) arg);
+                // we used to emit the legacy (is-C arg) form, which standard
+                // solvers reject.  The node name is stored as "is-C", so strip
+                // the prefix here.  Ported from the SMTStabilizer fork.
+                const std::string& tester = node->getName();
+                const std::string ctor = (tester.rfind("is-", 0) == 0) ? tester.substr(3) : tester;
                 const auto& children = node->getChildren();
                 if (children.empty()) {
-                    out << node->getName();
+                    out << "(_ is " << ctor << ")";
                 } else {
-                    out << "(" << node->getName();
+                    out << "((_ is " << ctor << ")";
                     work_stack.emplace_back(nullptr, 2);  // )
                     for (int i = children.size() - 1; i >= 0; i--) {
                         work_stack.emplace_back(children[i].get(), 0);
                         work_stack.emplace_back(nullptr, 1);  // space
                     }
+                }
+                break;
+            }
+            case NODE_KIND::NT_DT_UPDATER: {
+                // ((_ update <selector>) t v) — ported from the SMTStabilizer fork.
+                const auto& children = node->getChildren();
+                out << "((_ update " << node->getName() << ")";
+                work_stack.emplace_back(nullptr, 2);  // )
+                for (int i = children.size() - 1; i >= 0; i--) {
+                    work_stack.emplace_back(children[i].get(), 0);
+                    work_stack.emplace_back(nullptr, 1);  // space
+                }
+                break;
+            }
+            // TERM ANNOTATIONS: (! <term> :pattern (...) :qid q ...).
+            // Ported from the SMTStabilizer fork: these used to be parsed and
+            // then dropped, so quantifier triggers silently vanished from the
+            // printed output.
+            case NODE_KIND::NT_ATTRIBUTE: {
+                const auto& children = node->getChildren();
+                out << "(!";
+                work_stack.emplace_back(nullptr, 2);  // )
+                for (int i = children.size() - 1; i >= 0; i--) {
+                    work_stack.emplace_back(children[i].get(), 0);
+                    work_stack.emplace_back(nullptr, 1);  // space
+                }
+                break;
+            }
+            case NODE_KIND::NT_PATTERN: {
+                const auto& children = node->getChildren();
+                out << ":pattern (";
+                work_stack.emplace_back(nullptr, 2);  // )
+                for (int i = children.size() - 1; i >= 0; i--) {
+                    work_stack.emplace_back(children[i].get(), 0);
+                    if (i) work_stack.emplace_back(nullptr, 1);  // space
+                }
+                break;
+            }
+            case NODE_KIND::NT_NO_PATTERN: {
+                out << ":no-pattern ";
+                if (node->getChildrenSize() > 0) {
+                    work_stack.emplace_back(node->getChild(0).get(), 0);
+                }
+                break;
+            }
+            case NODE_KIND::NT_WEIGHT: {
+                out << ":weight ";
+                if (node->getChildrenSize() > 0) {
+                    work_stack.emplace_back(node->getChild(0).get(), 0);
+                }
+                break;
+            }
+            case NODE_KIND::NT_QID:
+                out << ":qid " << node->getName();
+                break;
+            // TUPLE OPERATORS — ported from the SMTStabilizer fork.
+            case NODE_KIND::NT_TUPLE_UNIT:
+                out << "tuple.unit";
+                break;
+            case NODE_KIND::NT_TUPLE_CONSTRUCTOR: {
+                const auto& children = node->getChildren();
+                out << "(tuple";
+                work_stack.emplace_back(nullptr, 2);  // )
+                for (int i = children.size() - 1; i >= 0; i--) {
+                    work_stack.emplace_back(children[i].get(), 0);
+                    work_stack.emplace_back(nullptr, 1);  // space
+                }
+                break;
+            }
+            case NODE_KIND::NT_TUPLE_SELECT:
+            case NODE_KIND::NT_TUPLE_UPDATE:
+            case NODE_KIND::NT_TUPLE_PROJECT: {
+                // ((_ tuple.select i) t), ((_ tuple.update i) t v),
+                // ((_ tuple.project i ...) t).  The index children are stored
+                // after the tuple term, so emit them into the index list first.
+                const auto& children = node->getChildren();
+                const size_t nidx = (kind == NODE_KIND::NT_TUPLE_UPDATE) ? 1
+                                  : (kind == NODE_KIND::NT_TUPLE_SELECT) ? 1
+                                  : (children.size() >= 1 ? children.size() - 1 : 0);
+                out << "((_ " << kindToString(kind);
+                work_stack.emplace_back(nullptr, 2);  // )
+                // terms: tuple (child 0), then the value for tuple.update
+                if (kind == NODE_KIND::NT_TUPLE_UPDATE && children.size() >= 3) {
+                    work_stack.emplace_back(children[2].get(), 0);
+                    work_stack.emplace_back(nullptr, 1);  // space
+                }
+                if (!children.empty()) {
+                    work_stack.emplace_back(children[0].get(), 0);
+                    work_stack.emplace_back(nullptr, 1);  // space
+                }
+                work_stack.emplace_back(")", 4);
+                for (size_t i = nidx; i >= 1; i--) {
+                    work_stack.emplace_back(children[i].get(), 0);
+                    work_stack.emplace_back(nullptr, 1);  // space
                 }
                 break;
             }

--- a/src/ir/number.cpp
+++ b/src/ir/number.cpp
@@ -731,6 +731,10 @@ HighPrecisionInteger::HighPrecisionInteger(long i) : value(i) {}
 
 HighPrecisionInteger::HighPrecisionInteger(unsigned long i) : value(i) {}
 
+// mpz_class has no unsigned long long constructor, so go through the decimal
+// string to stay exact on platforms where unsigned long is narrower.
+HighPrecisionInteger::HighPrecisionInteger(unsigned long long i) : value(std::to_string(i)) {}
+
 HighPrecisionInteger::HighPrecisionInteger(double d) : value(d) {}
 
 HighPrecisionInteger::HighPrecisionInteger(const std::string& s, int base) {

--- a/src/ir/sort.cpp
+++ b/src/ir/sort.cpp
@@ -163,6 +163,12 @@ namespace SOMTParser{
         return insertSortToBucket(sort);
     }
 
+    // Ported from the SMTStabilizer fork.
+    std::shared_ptr<Sort> SortManager::createTupleSort(const std::vector<std::shared_ptr<Sort>>& fields) {
+        auto sort = std::make_shared<Sort>(SORT_KIND::SK_TUPLE, "Tuple", 0, fields);
+        return insertSortToBucket(sort);
+    }
+
     std::shared_ptr<Sort> SortManager::createDatatypeSort(const std::string& name,
             const std::vector<Sort::DtConstructor>& constructors) {
         auto sort = std::make_shared<Sort>(SORT_KIND::SK_DATATYPE, name, 0);

--- a/test/integration/test_options_config.cpp
+++ b/test/integration/test_options_config.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "somtparser/frontend/parser.h"
+#include "test_helpers.h"
 #include <iostream>
 #include <cassert>
 
@@ -42,6 +43,31 @@ int main() {
     std::string opts2 = parser2->optionToString();
     std::cout << opts2 << std::endl;
     assert(opts2.find("QF_BV") != std::string::npos);
+
+    std::cout << "\n\n=== Test 3b: setOption with a string literal ===" << std::endl;
+    // Regression: a string literal used to bind to the bool overload
+    // (pointer-to-bool is a standard conversion, which outranks the
+    // user-defined conversion to std::string), so passing "false" turned the
+    // option ON. Every spelling below must mean the same thing.
+    // VERIFY, not assert: this file is built with -DNDEBUG in Release, where
+    // assert() compiles away entirely.
+    {
+        auto p = newParser();
+        p->setOption("keep_let", "false");
+        VERIFY(p->getOptions()->getKeepLet() == false);
+        p->setOption("keep_let", "true");
+        VERIFY(p->getOptions()->getKeepLet() == true);
+        p->setOption("keep_let", std::string("false"));
+        VERIFY(p->getOptions()->getKeepLet() == false);
+        p->setOption("keep_let", true);   // genuine bool still works
+        VERIFY(p->getOptions()->getKeepLet() == true);
+        p->setOption("keep_let", false);
+        VERIFY(p->getOptions()->getKeepLet() == false);
+        // Non-boolean options must still see the literal as its text.
+        p->setOption("precision", "512");
+        VERIFY(p->getOptions()->getEvaluatePrecision() == 512);
+        std::cout << "setOption string-literal overload OK" << std::endl;
+    }
 
     std::cout << "\n\n=== Test 4: Parsing file with options ===" << std::endl;
     auto parser3 = newParser();

--- a/test/regression/test_smtstabilizer_backport.cpp
+++ b/test/regression/test_smtstabilizer_backport.cpp
@@ -1,0 +1,245 @@
+// Regression tests for the fixes and features brought over from the
+// SMTStabilizer fork of SOMTParser (https://github.com/shaowei-cai-group/SMTStabilizer).
+//
+// Each case below either pins a printer/parser bug that used to produce
+// unparsable output, or covers a theory/annotation feature that the parser
+// previously rejected outright.
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "somtparser/frontend/parser.h"
+#include "test_helpers.h"
+
+using namespace SOMTParser;
+
+namespace {
+
+// Parse a single expression under the given declarations and print it back.
+std::string roundTrip(const std::string& decls, const std::string& expr) {
+    ParserPtr parser = newParser();
+    if (!decls.empty()) parser->parseStr(decls);
+    auto node = parser->mkExpr(expr);
+    VERIFY(node);
+    return parser->toString(node);
+}
+
+// Parse a whole script and print back its first assertion.
+std::string firstAssertion(const std::string& script, bool preserve_annotations = false) {
+    ParserPtr parser = newParser();
+    parser->setOption(std::string("preserve_annotations"),
+                      std::string(preserve_annotations ? "true" : "false"));
+    parser->parseStr(script);
+    auto assertions = parser->getAssertions();
+    VERIFY(!assertions.empty());
+    return parser->toString(assertions[0]);
+}
+
+void expectEq(const std::string& what, const std::string& got, const std::string& want) {
+    if (got != want) {
+        std::cerr << "FAILED " << what << "\n  got : " << got << "\n  want: " << want << "\n";
+        std::abort();
+    }
+    std::cout << "  ok: " << what << " -> " << got << "\n";
+}
+
+// ── A1/A2: bv<->int conversions used to print as UNKNOWN_KIND, and the
+// indexed forms lost their ((_ ...) ...) shape entirely. ──────────────────
+void test_bv_int_conversions() {
+    std::cout << "-- bitvector/integer conversions --\n";
+    const std::string bv_decl = "(declare-fun x () (_ BitVec 8))";
+    const std::string int_decl = "(declare-fun i () Int)";
+
+    expectEq("bv2int", roundTrip(bv_decl, "(bv2int x)"), "(bv2int x)");
+    expectEq("bv2nat", roundTrip(bv_decl, "(bv2nat x)"), "(bv2nat x)");
+    expectEq("int2bv indexed", roundTrip(int_decl, "((_ int2bv 8) i)"), "((_ int2bv 8) i)");
+    // B: the indexed nat2bv form used to abort on a 2-parameter assertion.
+    expectEq("nat2bv indexed", roundTrip(int_decl, "((_ nat2bv 8) i)"), "((_ nat2bv 8) i)");
+
+    // C3: SMT-LIB 2.7 spellings.
+    expectEq("ubv_to_int", roundTrip(bv_decl, "(ubv_to_int x)"), "(ubv_to_int x)");
+    expectEq("sbv_to_int", roundTrip(bv_decl, "(sbv_to_int x)"), "(sbv_to_int x)");
+}
+
+// ── A3: the regex sort printed as "(RegEx String)", which the parser's own
+// sort reader (which accepts "RegLan") could not read back. ───────────────
+void test_reglan_sort_round_trips() {
+    std::cout << "-- RegLan sort --\n";
+    ParserPtr parser = newParser();
+    parser->parseStr("(declare-fun r () RegLan)");
+    auto vars = parser->getVariables();
+    VERIFY(vars.size() == 1);
+    const std::string printed = vars[0]->getSort()->toString();
+    expectEq("RegLan sort", printed, "RegLan");
+
+    // The printed spelling must parse back into the same sort.
+    ParserPtr again = newParser();
+    again->parseStr("(declare-fun r2 () " + printed + ")");
+    auto vars2 = again->getVariables();
+    VERIFY(vars2.size() == 1 && vars2[0]->getSort()->isReg());
+}
+
+// ── A4/C4: datatype tester and updater. ───────────────────────────────────
+void test_datatype_tester_and_updater() {
+    std::cout << "-- datatype tester/updater --\n";
+    const std::string decls =
+        "(declare-datatypes ((L 0)) (((nil) (cons (hd Int) (tl L)))))\n"
+        "(declare-fun l () L)\n";
+
+    // A4: the tester used to print in the legacy (is-nil l) form, which is not
+    // SMT-LIB 2.6 syntax; both spellings must parse and print the standard one.
+    expectEq("tester indexed input", roundTrip(decls, "((_ is nil) l)"), "((_ is nil) l)");
+    expectEq("tester legacy input", roundTrip(decls, "(is-nil l)"), "((_ is nil) l)");
+
+    // C4: ((_ update <selector>) t v) was rejected outright.
+    expectEq("updater", roundTrip(decls, "((_ update hd) l 7)"), "((_ update hd) l 7)");
+}
+
+// ── C2: tuple theory was entirely missing; (Tuple Int Int) did not parse. ──
+void test_tuple_theory() {
+    std::cout << "-- tuple theory --\n";
+    const std::string decls =
+        "(declare-fun t () (Tuple Int Int Bool))\n"
+        "(declare-fun u () UnitTuple)\n";
+
+    ParserPtr parser = newParser();
+    parser->parseStr(decls);
+    for (auto& v : parser->getVariables()) {
+        if (v->getName() == "t") {
+            expectEq("tuple sort", v->getSort()->toString(), "(Tuple Int Int Bool)");
+            VERIFY(v->getSort()->isTuple());
+        }
+        if (v->getName() == "u") {
+            expectEq("unit tuple sort", v->getSort()->toString(), "UnitTuple");
+        }
+    }
+
+    expectEq("tuple constructor", roundTrip(decls, "(tuple 1 2 true)"), "(tuple 1 2 true)");
+    expectEq("tuple.unit", roundTrip(decls, "tuple.unit"), "tuple.unit");
+    expectEq("tuple.select", roundTrip(decls, "((_ tuple.select 0) t)"), "((_ tuple.select 0) t)");
+    expectEq("tuple.update", roundTrip(decls, "((_ tuple.update 0) t 5)"), "((_ tuple.update 0) t 5)");
+    expectEq("tuple.project", roundTrip(decls, "((_ tuple.project 2 0) t)"), "((_ tuple.project 2 0) t)");
+
+    // Element sorts must follow the tuple's field sorts.
+    ParserPtr p2 = newParser();
+    p2->parseStr(decls);
+    auto sel = p2->mkExpr("((_ tuple.select 2) t)");
+    VERIFY(sel && sel->getSort()->isBool());
+    auto proj = p2->mkExpr("((_ tuple.project 2 0) t)");
+    VERIFY(proj && proj->getSort()->toString() == "(Tuple Bool Int)");
+}
+
+// ── C1: quantifier annotations were parsed and then dropped, so triggers
+// silently vanished from the printed formula. ─────────────────────────────
+void test_quantifier_annotations() {
+    std::cout << "-- quantifier annotations --\n";
+    const std::string script =
+        "(declare-fun f (Int) Int)\n"
+        "(assert (forall ((x Int)) (! (> (f x) 0) :pattern ((f x)) :qid myq :weight 5)))\n";
+
+    // Default: annotations are dropped, exactly as before.
+    expectEq("annotations dropped by default", firstAssertion(script, false),
+             "(forall ((x Int)) (> (f x) 0))");
+
+    // Opt in and they survive the round trip.
+    expectEq("annotations preserved", firstAssertion(script, true),
+             "(forall ((x Int)) (! (> (f x) 0) :pattern ((f x)) :qid myq :weight 5))");
+
+    const std::string no_pattern =
+        "(declare-fun f (Int) Int)\n"
+        "(assert (forall ((x Int)) (! (> (f x) 1) :no-pattern (f x))))\n";
+    expectEq(":no-pattern preserved", firstAssertion(no_pattern, true),
+             "(forall ((x Int)) (! (> (f x) 1) :no-pattern (f x)))");
+
+    // Unknown annotations must still be skipped rather than aborting the parse,
+    // in both modes.
+    const std::string unknown_kw =
+        "(declare-fun f (Int) Int)\n"
+        "(assert (forall ((x Int)) (! (> (f x) 2) :lblpos lbl :skolemid sk)))\n";
+    expectEq("unknown annotations skipped", firstAssertion(unknown_kw, true),
+             "(forall ((x Int)) (> (f x) 2))");
+
+    // :named keeps its existing behaviour: recorded, not wrapped.
+    ParserPtr parser = newParser();
+    parser->setOption(std::string("preserve_annotations"), std::string("true"));
+    parser->parseStr("(declare-fun p () Bool)\n(assert (! p :named a0))\n");
+    expectEq(":named unchanged", parser->toString(parser->getAssertions()[0]), "p");
+}
+
+// ── D: default logic is ALL, and an unknown logic name falls back to ALL
+// instead of disabling every theory. ──────────────────────────────────────
+void test_logic_defaults() {
+    std::cout << "-- logic defaults --\n";
+    ParserPtr parser = newParser();
+    expectEq("default logic", parser->getOptions()->getLogic(), "ALL");
+
+    VERIFY(parser->getOptions()->setLogic("QF_LIA"));
+    expectEq("explicit logic", parser->getOptions()->getLogic(), "QF_LIA");
+
+    VERIFY(!parser->getOptions()->setLogic("QF_MADE_UP"));
+    expectEq("unknown logic falls back", parser->getOptions()->getLogic(), "ALL");
+}
+
+// ── Commutative operands get a canonical order; equal-hash ties keep input
+// order so the AST is reproducible. ───────────────────────────────────────
+void test_stable_commutative_order() {
+    std::cout << "-- stable commutative ordering --\n";
+    const std::string decls = "(declare-fun a () Int)\n(declare-fun b () Int)\n(declare-fun c () Int)\n";
+    const std::string one = roundTrip(decls, "(+ a b c)");
+    expectEq("(+ a b c) == (+ c b a)", roundTrip(decls, "(+ c b a)"), one);
+    expectEq("(+ a b c) == (+ b c a)", roundTrip(decls, "(+ b c a)"), one);
+
+    // Newly recognised symmetric operators.
+    const std::string bv_decls = "(declare-fun x () (_ BitVec 4))\n(declare-fun y () (_ BitVec 4))\n";
+    expectEq("bvnand symmetric", roundTrip(bv_decls, "(bvnand y x)"), roundTrip(bv_decls, "(bvnand x y)"));
+    expectEq("bvxnor symmetric", roundTrip(bv_decls, "(bvxnor y x)"), roundTrip(bv_decls, "(bvxnor x y)"));
+
+    // Quantifiers must NOT be reordered: the bound-variable list stays first.
+    ParserPtr parser = newParser();
+    parser->parseStr("(declare-fun f (Int Int) Bool)\n(assert (forall ((x Int) (y Int)) (f x y)))\n");
+    expectEq("quantifier shape kept", parser->toString(parser->getAssertions()[0]),
+             "(forall ((x Int) (y Int)) (f x y))");
+}
+
+// ── C5: small utility additions. ──────────────────────────────────────────
+void test_utility_additions() {
+    std::cout << "-- utility additions --\n";
+    VERIFY(BitVectorUtils::bvIsMaxSigned("#b0111"));
+    VERIFY(!BitVectorUtils::bvIsMaxSigned("#b1111"));
+    VERIFY(BitVectorUtils::bvIsMinSigned("#b1000"));
+    VERIFY(!BitVectorUtils::bvIsMinSigned("#b1001"));
+    VERIFY(BitVectorUtils::bvIsMaxUnsigned("#b1111"));
+    VERIFY(BitVectorUtils::bvIsNegOne("#b1111"));
+    VERIFY(!BitVectorUtils::bvIsNegOne("#b1110"));
+    VERIFY(BitVectorUtils::bvCompareToUint("#b0101", 5) == 0);
+    VERIFY(BitVectorUtils::bvCompareToUint("#b0101", 6) < 0);
+    VERIFY(BitVectorUtils::bvCompareToUint("#b0101", 4) > 0);
+    // A value wider than 64 bits with a set high bit exceeds any uint64_t.
+    VERIFY(BitVectorUtils::bvCompareToUint("#b1" + std::string(64, '0'), UINT64_MAX) > 0);
+    expectEq("mkOnes", BitVectorUtils::mkOnes(Integer(4)), "#b1111");
+
+    expectEq("strUnquote", StringUtils::strUnquote("\"abc\""), "abc");
+    expectEq("strUnquote unquoted", StringUtils::strUnquote("abc"), "abc");
+
+    // 64-bit unsigned values must survive without narrowing.
+    Integer big(static_cast<unsigned long long>(UINT64_MAX));
+    expectEq("Integer(unsigned long long)", big.toString(), "18446744073709551615");
+    std::cout << "  ok: utility additions\n";
+}
+
+}  // namespace
+
+int main() {
+    std::cout << "======= SMTStabilizer backport regression tests =======\n";
+    test_bv_int_conversions();
+    test_reglan_sort_round_trips();
+    test_datatype_tester_and_updater();
+    test_tuple_theory();
+    test_quantifier_annotations();
+    test_logic_defaults();
+    test_stable_commutative_order();
+    test_utility_additions();
+    std::cout << "All SMTStabilizer backport tests passed.\n";
+    return 0;
+}


### PR DESCRIPTION
## Background

[SMTStabilizer](https://github.com/shaowei-cai-group/SMTStabilizer) (MIT, © 2026 Xiang Zhang) vendors this parser under `src/parser/` and acknowledges it in its README. Their copy branched from an upstream revision around 2026-01, 99 commits behind `main`, and was reformatted plus renamespaced, so the delta is not readable with a plain `diff`.

I recovered it by locating the fork point via per-commit normalized similarity on `kind.h`/`number.cpp`, then diffing through a C++ lexical normalizer (comments stripped, whitespace collapsed, namespaces unified, statements re-split on `;{}`) to separate semantics from `clang-format` noise.

Their delta is 566 added / 599 removed normalized lines. Most of it is SMTStabilizer's own normalization logic and is **not** included here. What *is* included: four printer bugs their fork had already fixed that we still had, one neither side had fixed, and the features they needed to add.

Everything below was reproduced against a build of `main` before being fixed.

## Bugs fixed

| Before | After |
|---|---|
| `(bv2int x)` → `(UNKNOWN_KIND x)` | `(bv2int x)` |
| `((_ int2bv 8) i)` → `(UNKNOWN_KIND i 8)` | `((_ int2bv 8) i)` |
| `RegLan` sort printed as `(RegEx String)` | `RegLan` |
| `((_ is nil) l)` → `(is-nil l)` | `((_ is nil) l)` |
| `((_ nat2bv 8) i)` → throws | `((_ nat2bv 8) i)` |

- `kindToString` had no case for `NT_BV_TO_INT` / `NT_INT_TO_BV`, so both fell to `default: return "UNKNOWN_KIND"`.
- `NT_INT_TO_BV` / `NT_NAT_TO_BV` are indexed operators but were missing from the indexed print path.
- `Sort::toString` printed `(RegEx String)` while `parseSort` reads `RegLan` — our own output was unparsable by us. The test asserts the round trip, not just the string.
- The datatype tester used the legacy cvc4 `is-C` spelling instead of SMT-LIB 2.6 `((_ is C) x)`. Both spellings still parse; only printing changed.
- `((_ nat2bv m) t)` asserted on two operator parameters and never handled the indexed form's separate index argument. Neither side had fixed this one — it surfaced from the comparison.

## Features added

- **Tuple theory** — `SK_TUPLE`, `(Tuple T1 ... Tn)` / `UnitTuple` sorts, `tuple`, `tuple.unit`, and indexed `tuple.select` / `tuple.update` / `tuple.project`, with element-sort inference (`((_ tuple.project 2 0) t)` yields the correctly reordered tuple sort). `(Tuple Int Int)` previously failed to parse at all. `tuple` is on the shadow whitelist, so a user-declared function of that name still wins.
- **`((_ update <selector>) t v)`** — functional datatype update. The index position is a *symbol*, not a numeral, so it cannot use the generic indexed path; it is routed like `(_ is C)` through an internal prefix containing a control character, which cannot occur in an SMT-LIB symbol and so cannot collide with a user function.
- **`ubv_to_int` / `sbv_to_int`** — SMT-LIB 2.7 spellings.
- **Term annotations** — `(! <term> :pattern (...) :no-pattern t :weight n :qid q)` kept in the AST and printed back, behind the new `preserve_annotations` option.
- **Utilities** — stdin input (`parse("-")` or an empty filename), `HighPrecisionInteger(unsigned long long)`, `StringUtils::strUnquote`, and the bit-pattern predicates `bvIsMaxSigned` / `bvIsMinSigned` / `bvIsMaxUnsigned` / `bvIsNegOne` / `bvCompareToUint` / `mkOnes`.

### On `preserve_annotations` defaulting to off

Triggers control quantifier instantiation, so dropping them silently changes what a benchmark means downstream — that argues for on. But the annotation node is a new shape in the assertion tree that existing consumers do not expect, which argues for off. It ships **off**, preserving current behaviour exactly; both modes are tested. Flip the default in `options.h` if you would rather pay the compatibility cost for fidelity.

`:named` is unchanged in both modes: recorded for unsat cores, not wrapped.

## Deliberately not taken

- **Normalization core** — `sortParams` ordering for graph isomorphism, quantifier variable renaming (`Q1-0`), function deduplication (`_dup_N`). This is SMTStabilizer's product logic; in a general parser it destroys round-trip fidelity.
- **`util::BitVector`** replacing string bitvector arithmetic — our `src/core/util.cpp` already has a 64-bit fast path with a GMP fallback.
- **`condAssert` becoming a no-op under `NDEBUG`** — we deliberately moved to `throw std::runtime_error`, which is the better contract for a library.
- **Logic whitelist** — ours already lists 99 logics, a strict superset of their 90.
- **`isVar()` dropping the bare `NT_VAR` case** — a regression for us.

## Adjacent changes

- **Default logic is now `ALL`**, and an unrecognised logic name falls back to `ALL` (still returning `false`) rather than disabling every theory.
- **`sortParams` uses `stable_sort`.** Hash collisions previously fell through to `std::sort`'s unspecified order. Their fork breaks such ties by comparing `shared_ptr` values, which orders by heap address and is *not* reproducible across runs; input order is the only deterministic tie-break. `isCommutative`/`sortParams` already existed here and already ran unconditionally, so no new option was added.
- **`isCommutative` gained the remaining symmetric operators** — `bvnand`, `bvnor`, `bvxnor`, `bvcomp`, the add/mul overflow predicates, `fp.eq`, `fp.min`, `fp.max`. Their list also includes `NT_FORALL`/`NT_EXISTS`/`NT_FP_ADD`/`NT_FP_MUL`; those are omitted because their first child is a bound-variable list or a rounding mode rather than an operand, and `mkInternalOper` reorders *every* operand. Their code special-cases this at the call site, ours does not, so copying the list verbatim would corrupt quantifiers.
- **Dead `Number::ZERO` / `ONE` / `INFINITY` removed.** None had a definition or a user, so any reference was already a link error. `INFINITY` was worse than dead: it is a `<cmath>` macro, so a TU including `<cmath>` first silently turned the declaration into a function declaration via a vexing parse.

## Second commit: `setOption` string-literal trap

Found while writing the tests for this PR, independent of the backport. `Parser::setOption` is overloaded on `std::string`, `int`, `double` and `bool`, and `setOption("keep_let", "false")` selected the **bool** overload — `const char*` → `bool` is a standard conversion, which outranks the user-defined conversion to `std::string` — so the literal `"false"` turned the option **on**, silently.

Fixed with a `const char*` overload that forwards to the `std::string` one; it is an exact match on the value argument, so it outranks both candidates without ambiguity. No call site in tree was affected (callers pass a genuine `bool`, or go through `GlobalOptions::setOption`, which has no `bool` overload), so this closes a latent trap rather than changing behaviour.

## Attribution

Per the fork's MIT terms. No file headers were touched; attribution is inline at each ported call site, plus an **Acknowledgements** section in `CONTRIBUTORS.md` that explicitly notes they are not project contributors.

## Testing

**37/37 pass**, and both commits build and pass independently. New `test/regression/test_smtstabilizer_backport.cpp` covers every item above, including the negative cases: annotations dropped when the option is off, unknown annotation keywords skipped rather than aborting, and quantifier shape preserved under commutative reordering.

One note for a follow-up, scoped precisely after checking. CI is **not** affected: `test/run_all_tests.sh` builds with `CMAKE_BUILD_TYPE=Debug`, so assertions fire there. But `CMakeLists.txt` defaults a top-level build to **Release**, which adds `-DNDEBUG` — so the ordinary local `cmake -S . -B build -DSOMTPARSER_BUILD_TESTS=ON && ctest` path compiles every `assert()` away.

The suite has 718 `assert()` calls across 32 of 37 test files. Most are pure checks that merely stop verifying. The harmful ones are the **29 assertions in 4 files whose expression performs the work itself** (`assert(parser.parseStr("...")))` and friends) — under `-DNDEBUG` the call never happens, so the test body is hollow:

| file | such asserts |
|---|---|
| `integration/test_optimization.cpp` | 19 |
| `integration/test_options_config.cpp` | 7 |
| `parser/test_parse_oper_builtin_priority.cpp` | 2 |
| `api/test_uf_model_api.cpp` | 1 |

Demonstrated: a Release-built `test_optimization` prints "All optimization tests passed" without ever parsing an objective, and Release-built `test_options_config` Test 4 reports logic `ALL` instead of the `QF_UFLIA` it "asserted" it had set.

Verified there is no bug hiding behind this: a full Debug build, where every assertion fires, is also **37/37**. The tests are correct, just inert in the default build type. `test_helpers.h` already provides `VERIFY` for exactly this; the new block in this PR uses it. Converting the rest is a mechanical sweep worth doing separately.

That sweep is now open as #45. Merging both into `main` locally produces **no conflict** (the two touch disjoint lines of `test_options_config.cpp`); the only artifact is a duplicate `#include "test_helpers.h"` line for whichever lands second to delete. Merged result verified at 37/37 in both Release and Debug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)