### PR TITLE
Make the test suite actually verify in a Release build

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,19 @@ foreach(test_file IN LISTS SOMTPARSER_TEST_SOURCES)
     target_include_directories("${test_name}" PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
     target_link_libraries("${test_name}" PRIVATE SOMTParser::somtparser)
 
+    # A test must verify its expectations in every configuration. The default
+    # top-level build type is Release, which defines NDEBUG and so turns every
+    # assert() into a no-op -- including any whose expression does the work
+    # being tested. Tests use VERIFY from test_helpers.h, but undefine NDEBUG
+    # here as well so a stray assert() cannot silently stop checking. No
+    # library header is NDEBUG-conditional, so this cannot cause an ODR
+    # mismatch with libsomtparser.
+    if(MSVC)
+        target_compile_options("${test_name}" PRIVATE /UNDEBUG)
+    else()
+        target_compile_options("${test_name}" PRIVATE -UNDEBUG)
+    endif()
+
     add_test(NAME "SOMTParser.${test_name}" COMMAND "${test_name}")
     set_tests_properties("SOMTParser.${test_name}" PROPERTIES
         WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}")

--- a/test/api/test_context_dispatcher.cpp
+++ b/test/api/test_context_dispatcher.cpp
@@ -5,8 +5,8 @@
 #include "somtparser/frontend/parser.h"
 #include "somtparser/passes/op_dispatcher.h"
 #include <algorithm>
-#include <cassert>
 #include <iostream>
+#include "test_helpers.h"
 
 using namespace SOMTParser;
 
@@ -42,16 +42,16 @@ int main() {
     Parser parser;
     parser.mkVarInt("x");
     bool ok = parser.parseStr("(assert (> x 0))");
-    assert(ok);
+    VERIFY(ok);
 
     // get* delegate to ParserContext; need ParserContext& for get* via context()
     auto from_get = parser.getAssertions();
     auto from_ctx = static_cast<ParserContext&>(parser.context()).getAssertions();
-    assert(from_get.size() == from_ctx.size() && from_get.size() == 1);
+    VERIFY(from_get.size() == from_ctx.size() && from_get.size() == 1);
     std::cout << "getAssertions() == static_cast<ParserContext&>(context()).getAssertions() OK" << std::endl;
 
     Node root = from_get[0];
-    assert(kind(root) == NODE_KIND::NT_GT);
+    VERIFY(kind(root) == NODE_KIND::NT_GT);
 
     // OpDispatcher with Context& (parser.context()) — existing API
     OpDispatcher<int, Context> disp;
@@ -59,12 +59,12 @@ int main() {
     disp.otherwise(handler_fallback);
 
     int r1 = disp.dispatch(root, parser.context());
-    assert(r1 == 1);
+    VERIFY(r1 == 1);
     std::cout << "dispatch(node, parser.context()) OK" << std::endl;
 
     // Convenience: dispatch(Node) uses NullContext
     int r2 = disp.dispatch(root);
-    assert(r2 == 1);
+    VERIFY(r2 == 1);
     std::cout << "dispatch(node) with NullContext OK" << std::endl;
 
     // Fluent + sugar API
@@ -72,13 +72,13 @@ int main() {
     disp2.onGT(handler_gt).otherwise(handler_fallback);
     int r3 = disp2.dispatch(root, parser.context());
     int r4 = disp2.dispatch(root);
-    assert(r3 == 1 && r4 == 1);
+    VERIFY(r3 == 1 && r4 == 1);
     std::cout << "fluent + sugar (onGT/otherwise) and dispatch(node)/dispatch(node, context()) OK" << std::endl;
 
     // --- Recursive max-depth visitor (fluent + sugar, context carries dispatcher) ---
     parser.parseStr("(assert (and (> x 0) (< x 10)))");
     Node root2 = parser.getAssertions().back();
-    assert(kind(root2) == NODE_KIND::NT_AND);
+    VERIFY(kind(root2) == NODE_KIND::NT_AND);
 
     OpDispatcher<int, Context> depth_disp;
     depth_disp
@@ -98,12 +98,12 @@ int main() {
     int depth = depth_disp.dispatch(root2, depth_ctx);
     // Tree: AND(GT(x,0), LT(x,10)) -> AND depth 1 + max(GT depth, LT depth).
     // GT/LT each: 1 + max(VAR, CONST) = 1 + 1 = 2. So depth = 1 + 2 = 3.
-    assert(depth == 3);
+    VERIFY(depth == 3);
     std::cout << "recursive max-depth visitor: tree (and (> x 0) (< x 10)) depth=" << depth << " OK" << std::endl;
 
     // Single node depth
     int depth_single = depth_disp.dispatch(root, depth_ctx);
-    assert(depth_single == 2);  // GT(x, 0) -> 1 + max(1,1) = 2
+    VERIFY(depth_single == 2);  // GT(x, 0) -> 1 + max(1,1) = 2
     std::cout << "single (> x 0) depth=" << depth_single << " OK" << std::endl;
 
     std::cout << "======= All Context & Dispatcher tests passed =======" << std::endl;

--- a/test/api/test_define_fun_assert_roundtrip.cpp
+++ b/test/api/test_define_fun_assert_roundtrip.cpp
@@ -3,8 +3,8 @@
 #include <iostream>
 #include <string>
 #include <fstream>
-#include <cassert>
 #include <cstdio>
+#include "test_helpers.h"
 
 int main() {
     const char* tmp_file = "define_fun_assert_roundtrip.smt2";
@@ -19,7 +19,7 @@ int main() {
 )";
 
     std::ofstream out(tmp_file);
-    assert(out && "cannot create temp smt2 file");
+    VERIFY(out && "cannot create temp smt2 file");
     out << smt2_content;
     out.close();
 
@@ -27,15 +27,15 @@ int main() {
     bool ok = parser->parse(tmp_file);
     std::remove(tmp_file);
 
-    assert(ok && "parse should succeed");
+    VERIFY(ok && "parse should succeed");
     std::string dumped = parser->dumpSMT2();
     std::cout << dumped;
 
-    assert(dumped.find("(assert (eq x u))") != std::string::npos &&
+    VERIFY(dumped.find("(assert (eq x u))") != std::string::npos &&
            "dumpSMT2 must output (assert (eq x u)) with both arguments");
-    assert(dumped.find("(define-fun eq ") != std::string::npos &&
+    VERIFY(dumped.find("(define-fun eq ") != std::string::npos &&
            "dump must contain define-fun eq");
-    assert((dumped.find("(= x y)") != std::string::npos ||
+    VERIFY((dumped.find("(= x y)") != std::string::npos ||
             dumped.find("(= y x)") != std::string::npos) &&
            "define-fun eq body must preserve both parameters");
 

--- a/test/api/test_evaluate_fp_dispatch.cpp
+++ b/test/api/test_evaluate_fp_dispatch.cpp
@@ -6,68 +6,68 @@
 #include "somtparser/core/util.h"
 #include "somtparser/frontend/parser.h"
 #include "somtparser/ir/number.h"
-#include <cassert>
+#include "test_helpers.h"
 
 static void assert_fp32_near(const std::shared_ptr<SOMTParser::DAGNode>& ev, float expected, float eps = 5e-4f) {
-    assert(ev && !ev->isErr() && ev->isCFP());
+    VERIFY(ev && !ev->isErr() && ev->isCFP());
     auto v = SOMTParser::fpNodeToFloat32(ev);
-    assert(v.has_value());
-    assert(std::fabs(*v - expected) < eps);
+    VERIFY(v.has_value());
+    VERIFY(std::fabs(*v - expected) < eps);
 }
 
 static void eval_expect_fp32(SOMTParser::ParserPtr& parser, SOMTParser::ModelPtr& model, const char* smt, float expected,
                              float eps = 5e-4f) {
     auto e = parser->mkExpr(smt);
-    assert(e && !e->isErr());
+    VERIFY(e && !e->isErr());
     auto ev = parser->evaluate(e, model);
     assert_fp32_near(ev, expected, eps);
 }
 
 static void eval_expect_bool(SOMTParser::ParserPtr& parser, SOMTParser::ModelPtr& model, const char* smt, bool want_true) {
     auto e = parser->mkExpr(smt);
-    assert(e && !e->isErr());
+    VERIFY(e && !e->isErr());
     auto ev = parser->evaluate(e, model);
-    assert(ev && !ev->isErr());
+    VERIFY(ev && !ev->isErr());
     if (want_true) {
-        assert(ev->isTrue());
+        VERIFY(ev->isTrue());
     } else {
-        assert(ev->isFalse());
+        VERIFY(ev->isFalse());
     }
 }
 
 /// For operators that do not fold to a single constant, check evaluate preserves shape and constant leaves.
 static void eval_expect_structure_unchanged(SOMTParser::ParserPtr& parser, SOMTParser::ModelPtr& model, const char* smt) {
     auto e = parser->mkExpr(smt);
-    assert(e && !e->isErr());
+    VERIFY(e && !e->isErr());
     auto ev = parser->evaluate(e, model);
-    assert(ev && !ev->isErr());
-    assert(ev->getKind() == e->getKind());
-    assert(ev->getChildrenSize() == e->getChildrenSize());
+    VERIFY(ev && !ev->isErr());
+    VERIFY(ev->getKind() == e->getKind());
+    VERIFY(ev->getChildrenSize() == e->getChildrenSize());
     for (size_t i = 0; i < e->getChildrenSize(); ++i) {
         auto a = e->getChild(i);
         auto b = ev->getChild(i);
-        assert(a && b);
+        VERIFY(a && b);
         if (a->isConst()) {
-            assert(b->isConst());
-            assert(parser->toString(a) == parser->toString(b));
+            VERIFY(b->isConst());
+            VERIFY(parser->toString(a) == parser->toString(b));
         }
     }
 }
 
 static void assert_bv_unsigned_eq(const std::shared_ptr<SOMTParser::DAGNode>& ev, unsigned long expect_nat) {
-    assert(ev && !ev->isErr() && ev->isCBV());
+    VERIFY(ev && !ev->isErr() && ev->isCBV());
     const std::string bits = ev->toString();
-    assert(bits.size() >= 3 && bits[0] == '#' && bits[1] == 'b');
+    VERIFY(bits.size() >= 3 && bits[0] == '#' && bits[1] == 'b');
     SOMTParser::Integer n = SOMTParser::BitVectorUtils::bvToNat(bits);
-    assert(n.toULong() == expect_nat);
+    VERIFY(n.toULong() == expect_nat);
 }
 
 static void assert_bv_signed_eq(const std::shared_ptr<SOMTParser::DAGNode>& ev, long expect_s) {
-    assert(ev && !ev->isErr() && ev->isCBV());
+    VERIFY(ev && !ev->isErr() && ev->isCBV());
     const std::string bits = ev->toString();
-    assert(bits.size() >= 3 && bits.substr(0, 2) == "#b");
+    VERIFY(bits.size() >= 3 && bits.substr(0, 2) == "#b");
     SOMTParser::Integer s = SOMTParser::BitVectorUtils::bvToInt(bits);
-    assert(s.toLong() == expect_s);
+    VERIFY(s.toLong() == expect_s);
 }
 
 int main() {
@@ -90,10 +90,10 @@ int main() {
             return 1;
         }
         auto ev = p->evaluate(phi, model);
-        assert(ev && !ev->isErr());
-        assert(ev->getKind() == NODE_KIND::NT_FP_ADD);
-        assert(ev->getChildrenSize() == 3u);
-        assert(ev->getChild(2)->isCFP());
+        VERIFY(ev && !ev->isErr());
+        VERIFY(ev->getKind() == NODE_KIND::NT_FP_ADD);
+        VERIFY(ev->getChildrenSize() == 3u);
+        VERIFY(ev->getChild(2)->isCFP());
         assert_fp32_near(ev->getChild(2), 1.0f);
     }
 
@@ -121,7 +121,7 @@ int main() {
 (check-sat)
 (exit)
 )");
-        assert(ok && "eval_dispatch_qf_s inline must parse");
+        VERIFY(ok && "eval_dispatch_qf_s inline must parse");
     }
     {
         ParserPtr p = newParser();
@@ -138,7 +138,7 @@ int main() {
 (check-sat)
 (exit)
 )");
-        assert(ok && "eval_const_array inline must parse");
+        VERIFY(ok && "eval_const_array inline must parse");
     }
 
     // --- Phase A: FP constant folding (expected float32 values) ---
@@ -182,20 +182,20 @@ int main() {
     // --- Phase B: const_array default value simplifies to integer 3 ---
     {
         auto ca = parser->mkExpr("((as const (Array Int Int)) (+ 1 2))");
-        assert(ca && !ca->isErr());
+        VERIFY(ca && !ca->isErr());
         auto ev = parser->evaluate(ca, model);
-        assert(ev && !ev->isErr());
-        assert(ev->isConstArray());
-        assert(ev->getChildrenSize() >= 1u);
+        VERIFY(ev && !ev->isErr());
+        VERIFY(ev->isConstArray());
+        VERIFY(ev->getChildrenSize() >= 1u);
         auto defv = ev->getChild(0);
-        assert(defv && defv->isConst());
-        assert(parser->toInt(defv) == Integer(3));
+        VERIFY(defv && defv->isConst());
+        VERIFY(parser->toInt(defv) == Integer(3));
     }
     {
         auto ca = parser->mkExpr("((as const (Array Int Int)) 0)");
-        assert(ca && !ca->isErr());
+        VERIFY(ca && !ca->isErr());
         auto ev = parser->evaluate(ca, model);
-        assert(ev && !ev->isErr());
+        VERIFY(ev && !ev->isErr());
         (void)ev;
     }
 
@@ -208,13 +208,13 @@ int main() {
     // --- Phase C: fp <-> bv / to_fp (exact bit patterns where defined) ---
     {
         auto e = parser->mkExpr("((_ fp.to_ubv 16) RNE ((_ to_fp 8 24) RNE 2.0))");
-        assert(e && !e->isErr());
+        VERIFY(e && !e->isErr());
         auto ev = parser->evaluate(e, model);
         assert_bv_unsigned_eq(ev, 2ul);
     }
     {
         auto e = parser->mkExpr("((_ fp.to_sbv 16) RNE ((_ to_fp 8 24) RNE -1.0))");
-        assert(e && !e->isErr());
+        VERIFY(e && !e->isErr());
         auto ev = parser->evaluate(e, model);
         assert_bv_signed_eq(ev, -1l);
     }

--- a/test/api/test_let_evaluate.cpp
+++ b/test/api/test_let_evaluate.cpp
@@ -6,7 +6,6 @@
 
 #include "somtparser/frontend/parser.h"
 #include "somtparser/ir/dag.h"
-#include <cassert>
 #include "../test_helpers.h"
 
 using namespace SOMTParser;

--- a/test/api/test_node_api.cpp
+++ b/test/api/test_node_api.cpp
@@ -4,8 +4,8 @@
  */
 #include "somtparser/ir/node.h"
 #include "somtparser/frontend/parser.h"
-#include <cassert>
 #include <iostream>
+#include "test_helpers.h"
 
 using namespace SOMTParser;
 
@@ -16,76 +16,76 @@ int main() {
 
     // Leaf: constant
     Node leaf = parser->mkExpr("42");
-    assert(leaf);
-    assert(kind(leaf) == NODE_KIND::NT_CONST);
-    assert(sort(leaf));
-    assert(numChildren(leaf) == 0);
-    assert(child(leaf, 0) == nullptr);
+    VERIFY(leaf);
+    VERIFY(kind(leaf) == NODE_KIND::NT_CONST);
+    VERIFY(sort(leaf));
+    VERIFY(numChildren(leaf) == 0);
+    VERIFY(child(leaf, 0) == nullptr);
     size_t count = 0;
     std::cout << "Leaf (42): " << parser->toString(leaf) << std::endl;
     for (Node c : children(leaf)) {
         std::cout << "Child: " << parser->toString(c) << std::endl;
         ++count;
     }
-    assert(count == 0);
+    VERIFY(count == 0);
     std::cout << "Leaf (42): kind=NT_CONST, numChildren=0, range size=0 OK" << std::endl;
 
     // (+ 1 2): parser may fold to constant 3 or keep ADD node; both are valid for testing Node API
     Node add = parser->mkExpr("(+ 1 2)");
-    assert(add);
+    VERIFY(add);
     std::cout << "(+ 1 2) -> " << parser->toString(add)
               << ", kind=" << (kind(add) == NODE_KIND::NT_CONST ? "NT_CONST" : "NT_ADD")
               << ", numChildren=" << numChildren(add) << std::endl;
 
     if (kind(add) == NODE_KIND::NT_CONST) {
         // Folded to constant 3 at parse time
-        assert(numChildren(add) == 0);
+        VERIFY(numChildren(add) == 0);
         count = 0;
         for (Node c : children(add)) { (void)c; ++count; }
-        assert(count == 0);
+        VERIFY(count == 0);
         std::cout << "  (folded to constant: 0 children) OK" << std::endl;
     } else {
         // Not folded; still ADD node with two children 1 and 2
-        assert(kind(add) == NODE_KIND::NT_ADD);
-        assert(numChildren(add) == 2);
+        VERIFY(kind(add) == NODE_KIND::NT_ADD);
+        VERIFY(numChildren(add) == 2);
         Node a = child(add, 0), b = child(add, 1);
-        assert(a && b);
+        VERIFY(a && b);
         count = 0;
         for (Node c : children(add)) {
             std::cout << "  child: " << parser->toString(c) << std::endl;
-            assert(c);
+            VERIFY(c);
             ++count;
         }
-        assert(count == 2);
+        VERIFY(count == 2);
         std::cout << "  (ADD with 2 children) OK" << std::endl;
     }
 
     // (+ x 2): with variable, no folding; must be ADD with 2 children
     parser->mkVarInt("x");
     Node addX = parser->mkExpr("(+ x 2)");
-    assert(addX);
-    assert(kind(addX) == NODE_KIND::NT_ADD);
-    assert(numChildren(addX) == 2);
+    VERIFY(addX);
+    VERIFY(kind(addX) == NODE_KIND::NT_ADD);
+    VERIFY(numChildren(addX) == 2);
     count = 0;
     std::cout << "(+ x 2): " << parser->toString(addX) << std::endl;
     for (Node c : children(addX)) {
         std::cout << "  child: " << parser->toString(c) << std::endl;
-        assert(c);
+        VERIFY(c);
         ++count;
     }
-    assert(count == 2);
+    VERIFY(count == 2);
     std::cout << "(+ x 2): kind=NT_ADD, numChildren=2, range-for count=2 OK" << std::endl;
 
     // Null safety
     Node empty;
-    assert(kind(empty) == NODE_KIND::NT_UNKNOWN);
-    assert(sort(empty) == nullptr);
-    assert(numChildren(empty) == 0);
-    assert(child(empty, 0) == nullptr);
+    VERIFY(kind(empty) == NODE_KIND::NT_UNKNOWN);
+    VERIFY(sort(empty) == nullptr);
+    VERIFY(numChildren(empty) == 0);
+    VERIFY(child(empty, 0) == nullptr);
 
     std::cout << "Empty node: " << parser->toString(empty) << std::endl;
     for (Node c : children(empty)) {
-        assert(false && "should not iterate");
+        VERIFY(false && "should not iterate");
     }
     std::cout << "Null node: safe defaults OK" << std::endl;
     std::cout << "All Node API tests passed." << std::endl;

--- a/test/api/test_rewriter.cpp
+++ b/test/api/test_rewriter.cpp
@@ -4,8 +4,8 @@
  */
 #include "somtparser/frontend/parser.h"
 #include "somtparser/passes/rewriter.h"
-#include <cassert>
 #include <iostream>
+#include "test_helpers.h"
 
 using namespace SOMTParser;
 
@@ -26,8 +26,8 @@ int main() {
     installDefaultRewriteRules(rewriter);
 
     Node result = rewriter.rewrite(root);  // default fixpoint true
-    assert(result && "rewrite should return non-null");
-    assert(result == origVar && "fixpoint: (and true (not (not p))) -> p");
+    VERIFY(result && "rewrite should return non-null");
+    VERIFY(result == origVar && "fixpoint: (and true (not (not p))) -> p");
     std::cout << "fixpoint (and true (not (not p))) -> p OK" << std::endl;
 
     // rewriteOnce alone may not reach p (depends on order); one round: (not (not p)) -> p, then (and true p) -> p next round
@@ -42,7 +42,7 @@ int main() {
     Node once1 = rewriter.rewriteOnce(root2);
     (void)once1;
     Node fixed = rewriter.rewrite(root2, true);
-    assert(fixed == expectQ && "fixpoint (and true (not (not q))) -> q");
+    VERIFY(fixed == expectQ && "fixpoint (and true (not (not q))) -> q");
     std::cout << "fixpoint (and true (not (not q))) -> q OK" << std::endl;
 
     // ADD: (+ x 0) -> x
@@ -51,7 +51,7 @@ int main() {
     Node lhs = manager->createNode(SortManager::INT_SORT, NODE_KIND::NT_ADD,
                                    "+", {rhs, zero});
     Node lhsRewritten = rewriter.rewrite(lhs);
-    assert(lhsRewritten == rhs && "(+ x 0) -> x");
+    VERIFY(lhsRewritten == rhs && "(+ x 0) -> x");
     std::cout << "ADD (+ x 0) -> x OK" << std::endl;
 
     std::cout << "======= All Rewriter tests passed =======" << std::endl;

--- a/test/api/test_uf_model_api.cpp
+++ b/test/api/test_uf_model_api.cpp
@@ -5,7 +5,7 @@
 #include "somtparser/ir/dag.h"
 #include "somtparser/ir/sort.h"
 #include "somtparser/core/util.h"
-#include <cassert>
+#include "test_helpers.h"
 
 static std::string uf_sanitize(const std::string& s) {
     std::string out;
@@ -33,36 +33,36 @@ static std::string uf_sym_key(const std::shared_ptr<SOMTParser::DAGNode>& app) {
 int main() {
     using namespace SOMTParser;
 
-    assert(sanitizeKey("a b\nc\t") == std::string("abc"));
-    assert(sanitizeKey("no_spaces") == "no_spaces");
-    assert(sanitizeKey("") == "");
+    VERIFY(sanitizeKey("a b\nc\t") == std::string("abc"));
+    VERIFY(sanitizeKey("no_spaces") == "no_spaces");
+    VERIFY(sanitizeKey("") == "");
 
     {
         ModelPtr m = newModel();
         ParserPtr p = newParser();
         auto v99 = p->mkConstInt(99);
         m->setUF("g", "k1", v99);
-        assert(m->hasUF("g"));
-        assert(!m->hasUF("h"));
-        assert(m->getUF("g", "k1") == v99);
-        assert(p->toString(m->getUF("g", "k1")) == "99");
-        assert(m->getUF("g", "missing")->isUnknown());
+        VERIFY(m->hasUF("g"));
+        VERIFY(!m->hasUF("h"));
+        VERIFY(m->getUF("g", "k1") == v99);
+        VERIFY(p->toString(m->getUF("g", "k1")) == "99");
+        VERIFY(m->getUF("g", "missing")->isUnknown());
     }
 
     {
         ParserPtr p = newParser();
-        assert(p->parseStr("(set-logic ALL)"));
+        VERIFY(p->parseStr("(set-logic ALL)"));
         auto f_dec = p->mkFuncDec("f", {SortManager::INT_SORT}, SortManager::INT_SORT);
         auto h_dec = p->mkFuncDec("h", {SortManager::INT_SORT, SortManager::INT_SORT}, SortManager::INT_SORT);
-        assert(f_dec && !f_dec->isErr());
-        assert(h_dec && !h_dec->isErr());
+        VERIFY(f_dec && !f_dec->isErr());
+        VERIFY(h_dec && !h_dec->isErr());
         (void)f_dec;
         (void)h_dec;
 
         auto app_f = p->mkExpr("(f 1)");
-        assert(app_f && app_f->isUFApplication());
+        VERIFY(app_f && app_f->isUFApplication());
         std::string key_f = uf_sym_key(app_f);
-        assert(key_f == "uf@@f@@1");
+        VERIFY(key_f == "uf@@f@@1");
 
         ModelPtr m = newModel();
         auto slot = p->mkVarInt(key_f);
@@ -71,17 +71,17 @@ int main() {
         m->add(slot, golden);
 
         auto ev = p->evaluate(app_f, m);
-        assert(ev && p->toString(ev) == "42");
+        VERIFY(ev && p->toString(ev) == "42");
 
         auto app_h = p->mkExpr("(h 2 3)");
-        assert(app_h && app_h->isUFApplication());
+        VERIFY(app_h && app_h->isUFApplication());
         std::string key_h = uf_sym_key(app_h);
-        assert(key_h == "uf@@h@@2@@3");
+        VERIFY(key_h == "uf@@h@@2@@3");
         auto slot_h = p->mkVarInt(key_h);
         m->addVar(slot_h);
         m->add(slot_h, p->mkConstInt(100));
         auto ev_h = p->evaluate(app_h, m);
-        assert(ev_h && p->toString(ev_h) == "100");
+        VERIFY(ev_h && p->toString(ev_h) == "100");
     }
 
     {
@@ -91,9 +91,9 @@ int main() {
         auto at0 = p->mkConstInt(11);
         m->setArrayDefault("A", defv);
         m->setArrayStore("A", "#b0", at0);
-        assert(m->getArraySelect("A", "#b0") == at0);
-        assert(m->getArraySelect("A", "#b1") == defv);
-        assert(m->getArraySelect("B", "#b0")->isUnknown());
+        VERIFY(m->getArraySelect("A", "#b0") == at0);
+        VERIFY(m->getArraySelect("A", "#b1") == defv);
+        VERIFY(m->getArraySelect("B", "#b0")->isUnknown());
     }
 
     ParserPtr p2 = newParser();
@@ -112,7 +112,7 @@ int main() {
 (check-sat)
 (exit)
 )");
-    assert(ok && "uf inline must parse");
+    VERIFY(ok && "uf inline must parse");
 
     std::cout << "test_uf_model_api: all assertions passed\n";
     return 0;

--- a/test/api/test_umbrella.cpp
+++ b/test/api/test_umbrella.cpp
@@ -3,8 +3,8 @@
  * Parser, Rewriter, Context, Node, etc. One include, no other project headers.
  */
 #include "somtparser/parser.h"
-#include <cassert>
 #include <iostream>
+#include "test_helpers.h"
 
 int main() {
     std::cout << "======= Umbrella Header Test =======\n";
@@ -12,18 +12,18 @@ int main() {
     // Parser API (from frontend/parser.h)
     SOMTParser::ParserPtr parser = SOMTParser::newParser();
     std::shared_ptr<SOMTParser::DAGNode> node = parser->mkExpr("(and true false)");
-    assert(node && node->isFalse());
+    VERIFY(node && node->isFalse());
     std::cout << "Parser: (and true false) -> " << parser->toString(node) << " OK\n";
 
     // Rewriter API (from passes/rewriter.h)
     SOMTParser::ParserPtr p2 = SOMTParser::newParser();
     p2->parseStr("(declare-const x Bool)");
     bool ok = p2->parseStr("(assert (not (not x)))");
-    assert(ok);
+    VERIFY(ok);
     std::shared_ptr<SOMTParser::DAGNode> n = p2->getAssertions().back();
     SOMTParser::Rewriter r(p2->getNodeManager());
     SOMTParser::Node simplified = r.rewrite(SOMTParser::Node(n));
-    assert(simplified);
+    VERIFY(simplified);
     std::cout << "Rewriter: (not (not x)) -> " << p2->toString(simplified) << " OK\n";
 
     // Context / ParserContext (from context + frontend)

--- a/test/api/test_visitor_api.cpp
+++ b/test/api/test_visitor_api.cpp
@@ -3,9 +3,9 @@
  * DAG traversal with visit-once guarantee; KindCounter example.
  */
 #include "somtparser/frontend/parser.h"
-#include <cassert>
 #include <iostream>
 #include <map>
+#include "test_helpers.h"
 
 using namespace SOMTParser;
 
@@ -35,8 +35,8 @@ int main() {
     Node leaf = parser->mkExpr("42");
     KindCounter c1;
     c1.walk(leaf);
-    assert(c1.total() == 1);
-    assert(c1.count(NODE_KIND::NT_CONST) == 1);
+    VERIFY(c1.total() == 1);
+    VERIFY(c1.count(NODE_KIND::NT_CONST) == 1);
     std::cout << "Leaf 42: total=1, NT_CONST=1 OK" << std::endl;
 
     // (+ x 2): ADD + VAR + CONST = 3 nodes, each visited once
@@ -44,10 +44,10 @@ int main() {
     Node add = parser->mkExpr("(+ x 2)");
     KindCounter c2;
     c2.walk(add);
-    assert(c2.total() == 3);
-    assert(c2.count(NODE_KIND::NT_ADD) == 1);
-    assert(c2.count(NODE_KIND::NT_VAR) == 1);
-    assert(c2.count(NODE_KIND::NT_CONST) == 1);
+    VERIFY(c2.total() == 3);
+    VERIFY(c2.count(NODE_KIND::NT_ADD) == 1);
+    VERIFY(c2.count(NODE_KIND::NT_VAR) == 1);
+    VERIFY(c2.count(NODE_KIND::NT_CONST) == 1);
     std::cout << "(+ x 2): total=3 (ADD=1, VAR=1, CONST=1) OK" << std::endl;
 
     // DAG with sharing: (and (or a b) (or a b)) — (or a b) shared, 4 nodes (AND + OR + a + b)
@@ -61,16 +61,16 @@ int main() {
                                        {sharedOr, sharedOr});
     KindCounter c3;
     c3.walk(andNode);
-    assert(c3.total() == 4 && "AND + OR + a + b, each once");
-    assert(c3.count(NODE_KIND::NT_AND) == 1);
-    assert(c3.count(NODE_KIND::NT_OR) == 1);
-    assert(c3.count(NODE_KIND::NT_VAR) == 2);
+    VERIFY(c3.total() == 4 && "AND + OR + a + b, each once");
+    VERIFY(c3.count(NODE_KIND::NT_AND) == 1);
+    VERIFY(c3.count(NODE_KIND::NT_OR) == 1);
+    VERIFY(c3.count(NODE_KIND::NT_VAR) == 2);
     std::cout << "(and (or a b) (or a b)): total=4 (DAG, shared subgraph visited once) OK" << std::endl;
 
     // Null root: no crash, 0 visits
     KindCounter c4;
     c4.walk(nullptr);
-    assert(c4.total() == 0);
+    VERIFY(c4.total() == 0);
     std::cout << "walk(nullptr): no visits OK" << std::endl;
 
     std::cout << "All NodeVisitor API tests passed." << std::endl;

--- a/test/integration/test_incremental.cpp
+++ b/test/integration/test_incremental.cpp
@@ -3,10 +3,10 @@
  */
 
 #include "somtparser/frontend/parser.h"
-#include <cassert>
 #include <chrono>
 #include <iostream>
 #include <sstream>
+#include "test_helpers.h"
 
 using namespace SOMTParser;
 using namespace std::chrono;
@@ -15,7 +15,7 @@ static void test_push_pop_assertions() {
     std::cout << "--- test_push_pop_assertions ---" << std::endl;
     Parser parser;
     parser.parseStr("(push 1) (assert true) (pop 1)");
-    assert(parser.getAssertions().size() == 0);
+    VERIFY(parser.getAssertions().size() == 0);
     std::cout << "PASS" << std::endl;
 }
 
@@ -23,7 +23,7 @@ static void test_push_pop_symbols() {
     std::cout << "--- test_push_pop_symbols ---" << std::endl;
     Parser parser;
     parser.parseStr("(push 1) (declare-const x Int) (pop 1)");
-    assert(!parser.isDeclaredVariable("x"));
+    VERIFY(!parser.isDeclaredVariable("x"));
     std::cout << "PASS" << std::endl;
 }
 
@@ -31,7 +31,7 @@ static void test_push_pop_objectives() {
     std::cout << "--- test_push_pop_objectives ---" << std::endl;
     Parser parser;
     parser.parseStr("(declare-const x Int) (push 1) (minimize x) (pop 1)");
-    assert(parser.getObjectives().size() == 0);
+    VERIFY(parser.getObjectives().size() == 0);
     std::cout << "PASS" << std::endl;
 }
 
@@ -48,9 +48,9 @@ static void test_nested_push_pop() {
         "  (assert (> x 1))"
         "(pop 1)"
     );
-    assert(!parser.isDeclaredVariable("x"));
-    assert(!parser.isDeclaredVariable("y"));
-    assert(parser.getAssertions().size() == 0);
+    VERIFY(!parser.isDeclaredVariable("x"));
+    VERIFY(!parser.isDeclaredVariable("y"));
+    VERIFY(parser.getAssertions().size() == 0);
     std::cout << "PASS" << std::endl;
 }
 
@@ -58,8 +58,8 @@ static void test_reset_assertions() {
     std::cout << "--- test_reset_assertions ---" << std::endl;
     Parser parser;
     parser.parseStr("(declare-const x Int) (assert (> x 0)) (reset-assertions)");
-    assert(parser.isDeclaredVariable("x"));
-    assert(parser.getAssertions().size() == 0);
+    VERIFY(parser.isDeclaredVariable("x"));
+    VERIFY(parser.getAssertions().size() == 0);
     std::cout << "PASS" << std::endl;
 }
 
@@ -67,27 +67,27 @@ static void test_reset() {
     std::cout << "--- test_reset ---" << std::endl;
     Parser parser;
     parser.parseStr("(declare-const x Int) (assert (> x 0)) (reset)");
-    assert(!parser.isDeclaredVariable("x"));
-    assert(parser.getAssertions().size() == 0);
+    VERIFY(!parser.isDeclaredVariable("x"));
+    VERIFY(parser.getAssertions().size() == 0);
     std::cout << "PASS" << std::endl;
 }
 
 static void test_nextCommand() {
     std::cout << "--- test_nextCommand ---" << std::endl;
     Parser parser;
-    assert(parser.loadStr("(set-logic QF_LIA) (declare-const x Int) (assert (> x 0))"));
+    VERIFY(parser.loadStr("(set-logic QF_LIA) (declare-const x Int) (assert (> x 0))"));
 
     Command cmd1 = parser.nextCommand();
-    assert(cmd1.type == CMD_TYPE::CT_SET_LOGIC);
+    VERIFY(cmd1.type == CMD_TYPE::CT_SET_LOGIC);
 
     Command cmd2 = parser.nextCommand();
-    assert(cmd2.type == CMD_TYPE::CT_DECLARE_CONST);
+    VERIFY(cmd2.type == CMD_TYPE::CT_DECLARE_CONST);
 
     Command cmd3 = parser.nextCommand();
-    assert(cmd3.type == CMD_TYPE::CT_ASSERT);
+    VERIFY(cmd3.type == CMD_TYPE::CT_ASSERT);
 
     Command cmd4 = parser.nextCommand();
-    assert(cmd4.type == CMD_TYPE::CT_EOF);
+    VERIFY(cmd4.type == CMD_TYPE::CT_EOF);
     std::cout << "PASS" << std::endl;
 }
 
@@ -98,10 +98,10 @@ static void test_command_script() {
     parser.parseStr("(set-logic QF_LIA) (declare-const x Int) (assert (> x 0))");
 
     const Script& script = parser.getScript();
-    assert(script.size() == 3);
-    assert(script[0].type == CMD_TYPE::CT_SET_LOGIC);
-    assert(script[1].type == CMD_TYPE::CT_DECLARE_CONST);
-    assert(script[2].type == CMD_TYPE::CT_ASSERT);
+    VERIFY(script.size() == 3);
+    VERIFY(script[0].type == CMD_TYPE::CT_SET_LOGIC);
+    VERIFY(script[1].type == CMD_TYPE::CT_DECLARE_CONST);
+    VERIFY(script[2].type == CMD_TYPE::CT_ASSERT);
     std::cout << "PASS" << std::endl;
 }
 
@@ -109,8 +109,8 @@ static void test_push_pop_levels() {
     std::cout << "--- test_push_pop_levels ---" << std::endl;
     Parser parser;
     parser.parseStr("(push 2) (declare-const x Int) (declare-const y Int) (pop 2)");
-    assert(!parser.isDeclaredVariable("x"));
-    assert(!parser.isDeclaredVariable("y"));
+    VERIFY(!parser.isDeclaredVariable("x"));
+    VERIFY(!parser.isDeclaredVariable("y"));
     std::cout << "PASS" << std::endl;
 }
 
@@ -124,8 +124,8 @@ static void test_push_pop_assertion_groups() {
         "  (assert (> x 1) :id g1)"
         "(pop 1)"
     );
-    assert(parser.getNamedAssertions().find("a1") == parser.getNamedAssertions().end());
-    assert(parser.getGroupedAssertions().find("g1") == parser.getGroupedAssertions().end());
+    VERIFY(parser.getNamedAssertions().find("a1") == parser.getNamedAssertions().end());
+    VERIFY(parser.getGroupedAssertions().find("g1") == parser.getGroupedAssertions().end());
     std::cout << "PASS" << std::endl;
 }
 
@@ -145,7 +145,7 @@ static void test_stress_loop_push_pop() {
     auto end = high_resolution_clock::now();
     auto ms = duration_cast<milliseconds>(end - start).count();
     std::cout << "  " << ITERATIONS << " push/pop cycles in " << ms << " ms" << std::endl;
-    assert(parser.getAssertions().empty());
+    VERIFY(parser.getAssertions().empty());
     std::cout << "PASS" << std::endl;
 }
 
@@ -164,13 +164,13 @@ static void test_stress_deep_nesting() {
         oss << "(pop 1)";
     }
     bool ok = parser.parseStr(oss.str());
-    assert(ok);
+    VERIFY(ok);
 
     auto end = high_resolution_clock::now();
     auto ms = duration_cast<milliseconds>(end - start).count();
     std::cout << "  " << DEPTH << " nested scopes parsed in " << ms << " ms" << std::endl;
-    assert(parser.getAssertions().empty());
-    assert(parser.getScopeDepth() == 0);
+    VERIFY(parser.getAssertions().empty());
+    VERIFY(parser.getScopeDepth() == 0);
     std::cout << "PASS" << std::endl;
 }
 
@@ -190,14 +190,14 @@ static void test_stress_many_symbols_in_scope() {
     for (int i = 0; i < VARS; ++i) {
         std::ostringstream oss;
         oss << "v" << i;
-        assert(parser.isDeclaredVariable(oss.str()));
+        VERIFY(parser.isDeclaredVariable(oss.str()));
     }
     parser.pop(1);
     // After pop, none should exist
     for (int i = 0; i < VARS; ++i) {
         std::ostringstream oss;
         oss << "v" << i;
-        assert(!parser.isDeclaredVariable(oss.str()));
+        VERIFY(!parser.isDeclaredVariable(oss.str()));
     }
 
     auto end = high_resolution_clock::now();
@@ -237,9 +237,9 @@ static void test_stress_mixed_operations() {
         parser.pop(1);
     }
     // After all pops, everything should be gone
-    assert(parser.getAssertions().size() == 0);
-    assert(parser.getSoftAssertions().size() == 0);
-    assert(parser.getObjectives().size() == 0);
+    VERIFY(parser.getAssertions().size() == 0);
+    VERIFY(parser.getSoftAssertions().size() == 0);
+    VERIFY(parser.getObjectives().size() == 0);
 
     auto end = high_resolution_clock::now();
     auto ms = duration_cast<milliseconds>(end - start).count();
@@ -258,7 +258,7 @@ static void test_stress_nextCommand_stream() {
     }
     Parser parser;
     parser.setCommandLogging(true);
-    assert(parser.loadStr(oss.str()));
+    VERIFY(parser.loadStr(oss.str()));
 
     // Now walk with nextCommand until EOF
     size_t count = 0;
@@ -268,7 +268,7 @@ static void test_stress_nextCommand_stream() {
         ++count;
     } while (cmd.type != CMD_TYPE::CT_EOF);
     // -1 because the last is EOF
-    assert(count - 1 == static_cast<size_t>(CMDS * 2));
+    VERIFY(count - 1 == static_cast<size_t>(CMDS * 2));
 
     auto end = high_resolution_clock::now();
     auto ms = duration_cast<milliseconds>(end - start).count();

--- a/test/integration/test_optimization.cpp
+++ b/test/integration/test_optimization.cpp
@@ -4,18 +4,18 @@
 
 #include "somtparser/frontend/parser.h"
 #include <iostream>
-#include <cassert>
+#include "test_helpers.h"
 
 static void test_minimize() {
     std::cout << "=== Testing (minimize x) ===" << std::endl;
     SOMTParser::Parser parser;
-    assert(parser.parseStr("(set-logic QF_LIA)"));
-    assert(parser.parseStr("(declare-const x Int)"));
-    assert(parser.parseStr("(minimize x)"));
+    VERIFY(parser.parseStr("(set-logic QF_LIA)"));
+    VERIFY(parser.parseStr("(declare-const x Int)"));
+    VERIFY(parser.parseStr("(minimize x)"));
     auto objs = parser.getObjectives();
-    assert(objs.size() == 1 && "expect one objective");
-    assert(objs[0]->isMinimize() && "objective should be minimize");
-    assert(objs[0]->getObjectiveTerm() && "minimize term should be non-null");
+    VERIFY(objs.size() == 1 && "expect one objective");
+    VERIFY(objs[0]->isMinimize() && "objective should be minimize");
+    VERIFY(objs[0]->getObjectiveTerm() && "minimize term should be non-null");
     std::cout << "  Objectives: " << objs.size() << ", first is minimize, term present." << std::endl;
     std::cout << "  ✓ minimize test passed" << std::endl;
 }
@@ -23,52 +23,52 @@ static void test_minimize() {
 static void test_maximize() {
     std::cout << "=== Testing (maximize y) ===" << std::endl;
     SOMTParser::Parser parser;
-    assert(parser.parseStr("(set-logic QF_LIA)"));
-    assert(parser.parseStr("(declare-const y Int)"));
-    assert(parser.parseStr("(maximize y)"));
+    VERIFY(parser.parseStr("(set-logic QF_LIA)"));
+    VERIFY(parser.parseStr("(declare-const y Int)"));
+    VERIFY(parser.parseStr("(maximize y)"));
     auto objs = parser.getObjectives();
-    assert(objs.size() == 1 && "expect one objective");
-    assert(objs[0]->isMaximize() && "objective should be maximize");
+    VERIFY(objs.size() == 1 && "expect one objective");
+    VERIFY(objs[0]->isMaximize() && "objective should be maximize");
     std::cout << "  ✓ maximize test passed" << std::endl;
 }
 
 static void test_multiple_objectives() {
     std::cout << "=== Testing multiple objectives ===" << std::endl;
     SOMTParser::Parser parser;
-    assert(parser.parseStr("(set-logic QF_LIA)"));
-    assert(parser.parseStr("(declare-const x Int)"));
-    assert(parser.parseStr("(declare-const y Int)"));
-    assert(parser.parseStr("(minimize x)"));
-    assert(parser.parseStr("(maximize y)"));
+    VERIFY(parser.parseStr("(set-logic QF_LIA)"));
+    VERIFY(parser.parseStr("(declare-const x Int)"));
+    VERIFY(parser.parseStr("(declare-const y Int)"));
+    VERIFY(parser.parseStr("(minimize x)"));
+    VERIFY(parser.parseStr("(maximize y)"));
     auto objs = parser.getObjectives();
-    assert(objs.size() == 2 && "expect two objectives");
-    assert(objs[0]->isMinimize() && objs[1]->isMaximize());
+    VERIFY(objs.size() == 2 && "expect two objectives");
+    VERIFY(objs[0]->isMinimize() && objs[1]->isMaximize());
     std::cout << "  ✓ multiple objectives test passed" << std::endl;
 }
 
 static void test_define_objective_and_lex_optimize() {
     std::cout << "=== Testing define-objective and lex-optimize ===" << std::endl;
     SOMTParser::Parser parser;
-    assert(parser.parseStr("(set-logic QF_LIA)"));
-    assert(parser.parseStr("(declare-const x Int)"));
-    assert(parser.parseStr("(declare-const y Int)"));
-    assert(parser.parseStr("(define-objective obj1 (minimize x))"));
-    assert(parser.parseStr("(define-objective obj2 (maximize y))"));
-    assert(parser.parseStr("(lex-optimize (obj1 obj2))"));
+    VERIFY(parser.parseStr("(set-logic QF_LIA)"));
+    VERIFY(parser.parseStr("(declare-const x Int)"));
+    VERIFY(parser.parseStr("(declare-const y Int)"));
+    VERIFY(parser.parseStr("(define-objective obj1 (minimize x))"));
+    VERIFY(parser.parseStr("(define-objective obj2 (maximize y))"));
+    VERIFY(parser.parseStr("(lex-optimize (obj1 obj2))"));
     auto objs = parser.getObjectives();
-    assert(objs.size() == 3 && "expect three: obj1, obj2, and lex-optimize composite");
-    assert(objs[2]->isLexOptimize() && "third should be lex-optimize");
-    assert(objs[2]->getObjectiveSize() == 2 && "lex-optimize should have two sub-objectives");
+    VERIFY(objs.size() == 3 && "expect three: obj1, obj2, and lex-optimize composite");
+    VERIFY(objs[2]->isLexOptimize() && "third should be lex-optimize");
+    VERIFY(objs[2]->getObjectiveSize() == 2 && "lex-optimize should have two sub-objectives");
     std::cout << "  ✓ define-objective and lex-optimize test passed" << std::endl;
 }
 
 static void test_empty_objectives_before_any_optimization() {
     std::cout << "=== Testing getObjectives() before any optimization ===" << std::endl;
     SOMTParser::Parser parser;
-    assert(parser.parseStr("(set-logic QF_LIA)"));
-    assert(parser.parseStr("(declare-const x Int)"));
+    VERIFY(parser.parseStr("(set-logic QF_LIA)"));
+    VERIFY(parser.parseStr("(declare-const x Int)"));
     auto objs = parser.getObjectives();
-    assert(objs.empty() && "expect no objectives before minimize/maximize");
+    VERIFY(objs.empty() && "expect no objectives before minimize/maximize");
     std::cout << "  ✓ empty objectives test passed" << std::endl;
 }
 

--- a/test/integration/test_options_config.cpp
+++ b/test/integration/test_options_config.cpp
@@ -9,18 +9,18 @@
 
 #include "somtparser/frontend/parser.h"
 #include <iostream>
-#include <cassert>
+#include "test_helpers.h"
 
 using namespace SOMTParser;
 
 int main() {
     auto parser = newParser();
-    assert(parser);
+    VERIFY(parser);
 
     std::cout << "=== Test 1: Default Configuration ===" << std::endl;
     std::string defaultOpts = parser->optionToString();
     std::cout << defaultOpts << std::endl;
-    assert(!defaultOpts.empty());
+    VERIFY(!defaultOpts.empty());
 
     std::cout << "\n\n=== Test 2: Modified Configuration ===" << std::endl;
     parser->getOptions()->setLogic("QF_LIA");
@@ -30,7 +30,7 @@ int main() {
     parser->getOptions()->setExpandRecursiveFunctions(true);
     std::string modOpts = parser->optionToString();
     std::cout << modOpts << std::endl;
-    assert(modOpts.find("QF_LIA") != std::string::npos);
+    VERIFY(modOpts.find("QF_LIA") != std::string::npos);
 
     std::cout << "\n\n=== Test 3: Using setOption method ===" << std::endl;
     auto parser2 = newParser();
@@ -41,21 +41,21 @@ int main() {
     parser2->getOptions()->setLogic("QF_BV");
     std::string opts2 = parser2->optionToString();
     std::cout << opts2 << std::endl;
-    assert(opts2.find("QF_BV") != std::string::npos);
+    VERIFY(opts2.find("QF_BV") != std::string::npos);
 
     std::cout << "\n\n=== Test 4: Parsing file with options ===" << std::endl;
     auto parser3 = newParser();
-    assert(parser3->parseStr("(set-logic QF_UFLIA)"));
-    assert(parser3->parseStr("(set-info :source \"Test source\")"));
-    assert(parser3->parseStr("(set-info :smt-lib-version \"2.6\")"));
-    assert(parser3->parseStr("(set-option :produce-models true)"));
-    assert(parser3->parseStr("(declare-const x Int)"));
-    assert(parser3->parseStr("(assert (> x 0))"));
-    assert(parser3->parseStr("(check-sat)"));
+    VERIFY(parser3->parseStr("(set-logic QF_UFLIA)"));
+    VERIFY(parser3->parseStr("(set-info :source \"Test source\")"));
+    VERIFY(parser3->parseStr("(set-info :smt-lib-version \"2.6\")"));
+    VERIFY(parser3->parseStr("(set-option :produce-models true)"));
+    VERIFY(parser3->parseStr("(declare-const x Int)"));
+    VERIFY(parser3->parseStr("(assert (> x 0))"));
+    VERIFY(parser3->parseStr("(check-sat)"));
     std::string opts3 = parser3->optionToString();
     std::cout << opts3 << std::endl;
-    assert(!opts3.empty());
-    assert(parser3->getAssertions().size() == 1);
+    VERIFY(!opts3.empty());
+    VERIFY(parser3->getAssertions().size() == 1);
 
     // strict SMT-LIB FP surface vs lenient dialect (no error: lines on stdout)
     std::cout << "\n\n=== Test 5: strict_smtlib / lenient FP surface ===" << std::endl;
@@ -63,19 +63,19 @@ int main() {
         auto p = newParser();
         p->setStrictSmtlib(false);
         auto e = p->mkExpr("(fp.sqrt ((_ to_fp 8 24) RNE 25.0))");
-        assert(e && !e->isErr() && e->isCFP());
+        VERIFY(e && !e->isErr() && e->isCFP());
     }
     {
         auto p = newParser();
         p->setStrictSmtlib(true);
         auto e = p->mkExpr("(fp.sqrt RNE ((_ to_fp 8 24) RNE 25.0))");
-        assert(e && !e->isErr() && e->isCFP());
+        VERIFY(e && !e->isErr() && e->isCFP());
     }
     {
         auto p = newParser();
         p->setStrictSmtlib(true);
         auto e = p->mkExpr("(fp.eq ((_ to_fp 8 24) RNE 1.0) ((_ to_fp 8 24) RNE 1.0))");
-        assert(e && !e->isErr() && e->isTrue());
+        VERIFY(e && !e->isErr() && e->isTrue());
     }
 
     return 0;

--- a/test/integration/test_readme.cpp
+++ b/test/integration/test_readme.cpp
@@ -6,7 +6,7 @@
 #include "somtparser/frontend/parser.h"
 #include <iostream>
 #include <unordered_set>
-#include <cassert>
+#include "test_helpers.h"
 
 void test_basic_parsing() {
     std::cout << "\n=== Testing Basic Parsing ===" << std::endl;
@@ -22,9 +22,9 @@ void test_basic_parsing() {
             (assert (> (+ x y) 10))
         )";
         
-        assert(parser.parseStr(smt_content) && "parse SMT content must succeed");
+        VERIFY(parser.parseStr(smt_content) && "parse SMT content must succeed");
         auto assertions = parser.getAssertions();
-        assert(assertions.size() == 1 && "should have one assertion");
+        VERIFY(assertions.size() == 1 && "should have one assertion");
         std::cout << "Parsed assertions:" << std::endl;
         for(auto constraint: assertions){
             std::cout << "  " << parser.toString(constraint) << std::endl;
@@ -48,8 +48,8 @@ void test_expression_building() {
         auto sum = parser->mkAdd(add_params);
         auto condition = parser->mkGt(sum, parser->mkConstInt(10));
         
-        assert(sum && condition);
-        assert(parser->toString(condition).find(">") != std::string::npos || parser->toString(condition).find("10") != std::string::npos);
+        VERIFY(sum && condition);
+        VERIFY(parser->toString(condition).find(">") != std::string::npos || parser->toString(condition).find("10") != std::string::npos);
         std::cout << "Sum expression: " << parser->toString(sum) << std::endl;
         std::cout << "Condition: " << parser->toString(condition) << std::endl;
         std::cout << "✓ Expression building test passed" << std::endl;
@@ -86,7 +86,7 @@ void test_formula_analysis() {
         parser->collectAtoms(formula, atoms);
         parser->collectVars(formula, vars);
         
-        assert(atoms.size() > 0 && vars.size() >= 2 && "formula should have atoms and variables");
+        VERIFY(atoms.size() > 0 && vars.size() >= 2 && "formula should have atoms and variables");
         std::cout << "Formula: " << parser->toString(formula) << std::endl;
         std::cout << "Found " << atoms.size() << " atoms and " << vars.size() << " variables" << std::endl;
         std::cout << "✓ Formula analysis test passed" << std::endl;
@@ -118,7 +118,7 @@ void test_formula_conversions() {
         auto cnf = parser->toCNF(formula_vec);
         auto dnf = parser->toDNF(formula);
         
-        assert(nnf && cnf && dnf);
+        VERIFY(nnf && cnf && dnf);
         std::cout << "Original: " << parser->toString(formula) << std::endl;
         std::cout << "NNF: " << parser->toString(nnf) << std::endl;
         std::cout << "CNF: " << parser->toString(cnf) << std::endl;
@@ -159,7 +159,7 @@ void test_model_evaluation() {
         model->add(z, parser->mkTrue());                          // x + y = 3.5 > 3 ✓
         
         auto result = parser->evaluate(formula, model);
-        assert(result && result->isTrue() && "evaluate with given model should yield true");
+        VERIFY(result && result->isTrue() && "evaluate with given model should yield true");
         std::cout << "Formula: " << parser->toString(formula) << std::endl;
         std::cout << "Result: " << parser->toString(result) << std::endl;
         std::cout << "✓ Model evaluation test passed" << std::endl;
@@ -179,8 +179,8 @@ void test_let_expression_expansion() {
         auto let_expr = parser->mkExpr("(let ((temp (+ x 1))) (> temp y))");
         auto expanded = parser->expandLet(let_expr);
         
-        assert(let_expr && expanded);
-        assert(parser->toString(expanded).find("temp") == std::string::npos || parser->toString(expanded).size() >= 5);
+        VERIFY(let_expr && expanded);
+        VERIFY(parser->toString(expanded).find("temp") == std::string::npos || parser->toString(expanded).size() >= 5);
         std::cout << "Let expression: " << parser->toString(let_expr) << std::endl;
         std::cout << "Expanded: " << parser->toString(expanded) << std::endl;
         std::cout << "✓ Let expression expansion test passed" << std::endl;
@@ -207,7 +207,7 @@ void test_enhanced_omt() {
         auto soft_assertions = parser->getSoftAssertions();
         auto soft_weights = parser->getSoftWeights();
         
-        assert(soft_assertions.size() == 2 && soft_weights.size() == 2);
+        VERIFY(soft_assertions.size() == 2 && soft_weights.size() == 2);
         std::cout << "Found " << soft_assertions.size() << " soft assertions" << std::endl;
         for (size_t i = 0; i < soft_assertions.size(); ++i) {
             std::cout << "Soft assertion " << i << " (weight " << parser->toString(soft_weights[i]) << "): "
@@ -252,8 +252,8 @@ void test_comprehensive_features() {
         
         auto eval_arithmetic = parser->evaluate(arithmetic_expr, model);
         auto eval_conditional = parser->evaluate(conditional_expr, model);
-        assert(eval_arithmetic && parser->toString(eval_arithmetic) == "13");
-        assert(eval_conditional && parser->toString(eval_conditional) == "8");
+        VERIFY(eval_arithmetic && parser->toString(eval_arithmetic) == "13");
+        VERIFY(eval_conditional && parser->toString(eval_conditional) == "8");
         std::cout << "Arithmetic expression evaluated: " << parser->toString(eval_arithmetic) << std::endl;
         std::cout << "Conditional expression evaluated: " << parser->toString(eval_conditional) << std::endl;
         

--- a/test/integration/test_theory_combination.cpp
+++ b/test/integration/test_theory_combination.cpp
@@ -2,7 +2,7 @@
 #include <string>
 #include <vector>
 #include "somtparser/frontend/parser.h"
-#include <cassert>
+#include "test_helpers.h"
 
 // Test combination of arithmetic and boolean logic
 void test_arithmetic_boolean_combination(SOMTParser::ParserPtr& parser) {
@@ -34,7 +34,7 @@ void test_arithmetic_boolean_combination(SOMTParser::ParserPtr& parser) {
         for (const auto& expr : expressions) {
             std::cout << "Expression: " << expr << std::endl;
             std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(expr);
-            assert(result && !result->isErr());
+            VERIFY(result && !result->isErr());
             std::cout << "  Result: " << parser->toString(result) << std::endl;
             std::cout << std::endl;
         }
@@ -75,7 +75,7 @@ void test_array_arithmetic_combination(SOMTParser::ParserPtr& parser) {
         for (const auto& expr : expressions) {
             std::cout << "Expression: " << expr << std::endl;
             std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(expr);
-            assert(result && !result->isErr());
+            VERIFY(result && !result->isErr());
             std::cout << "  Result: " << parser->toString(result) << std::endl;
             std::cout << std::endl;
         }
@@ -117,7 +117,7 @@ void test_bitvector_combination(SOMTParser::ParserPtr& parser) {
         for (const auto& expr : expressions) {
             std::cout << "Expression: " << expr << std::endl;
             std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(expr);
-            assert(result && !result->isErr());
+            VERIFY(result && !result->isErr());
             std::cout << "  Result: " << parser->toString(result) << std::endl;
             std::cout << std::endl;
         }
@@ -162,7 +162,7 @@ void test_string_combination(SOMTParser::ParserPtr& parser) {
         for (const auto& expr : expressions) {
             std::cout << "Expression: " << expr << std::endl;
             std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(expr);
-            assert(result && !result->isErr());
+            VERIFY(result && !result->isErr());
             std::cout << "  Result: " << parser->toString(result) << std::endl;
             std::cout << std::endl;
         }
@@ -205,7 +205,7 @@ void test_quantifier_combinations(SOMTParser::ParserPtr& parser) {
         for (const auto& expr : expressions) {
             std::cout << "Expression: " << expr << std::endl;
             std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(expr);
-            assert(result && !result->isErr());
+            VERIFY(result && !result->isErr());
             std::cout << "  Result: " << parser->toString(result) << std::endl;
             std::cout << std::endl;
         }
@@ -254,7 +254,7 @@ void test_real_world_examples(SOMTParser::ParserPtr& parser) {
         for (const auto& expr : expressions) {
             std::cout << "Expression: " << expr << std::endl;
             std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(expr);
-            assert(result && !result->isErr());
+            VERIFY(result && !result->isErr());
             std::cout << "  Result: " << parser->toString(result) << std::endl;
             std::cout << std::endl;
         }

--- a/test/parser/test_expressions.cpp
+++ b/test/parser/test_expressions.cpp
@@ -2,7 +2,7 @@
 #include <string>
 #include <vector>
 #include "somtparser/frontend/parser.h"
-#include <cassert>
+#include "test_helpers.h"
 
 // Test let expressions
 void test_let_expressions(SOMTParser::ParserPtr& parser) {
@@ -30,10 +30,10 @@ void test_let_expressions(SOMTParser::ParserPtr& parser) {
     for (const auto& expr : expressions) {
         std::cout << "Expression: " << expr << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(expr);
-        assert(result);
+        VERIFY(result);
         std::cout << "  Result: " << parser->toString(result) << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> expanded = parser->expandLet(result);
-        assert(expanded);
+        VERIFY(expanded);
         std::cout << "  Expanded: " << parser->toString(expanded) << std::endl;
         std::cout << std::endl;
     }
@@ -46,22 +46,22 @@ void test_cnf_bool_var_atom_roundtrip(SOMTParser::ParserPtr& parser) {
     parser->mkVarInt("y");
 
     std::shared_ptr<SOMTParser::DAGNode> phi = parser->mkExpr("(and (> x 0) (< y 3))");
-    assert(phi);
+    VERIFY(phi);
 
     std::shared_ptr<SOMTParser::DAGNode> nnf = parser->toNNF(phi);
-    assert(nnf);
+    VERIFY(nnf);
     std::vector<std::shared_ptr<SOMTParser::DAGNode>> expr_vec = {phi};
     std::shared_ptr<SOMTParser::DAGNode> cnf = parser->toCNF(expr_vec);
-    assert(cnf);
+    VERIFY(cnf);
 
     std::shared_ptr<SOMTParser::DAGNode> atom_gt = parser->mkExpr("(> x 0)");
-    assert(atom_gt);
+    VERIFY(atom_gt);
     std::shared_ptr<SOMTParser::DAGNode> b = parser->getCNFBoolVar(atom_gt);
-    assert(b && "getCNFBoolVar( (> x 0) ) should return the CNF bool var");
+    VERIFY(b && "getCNFBoolVar( (> x 0) ) should return the CNF bool var");
     std::shared_ptr<SOMTParser::DAGNode> a = parser->getCNFAtom(b);
-    assert(a == atom_gt);
-    assert(a && "getCNFAtom(b) should recover the atom");
-    assert(parser->toString(a) == parser->toString(atom_gt) && "recovered atom should be (> x 0)");
+    VERIFY(a == atom_gt);
+    VERIFY(a && "getCNFAtom(b) should recover the atom");
+    VERIFY(parser->toString(a) == parser->toString(atom_gt) && "recovered atom should be (> x 0)");
 
     std::cout << "  phi: " << parser->toString(phi) << std::endl;
     std::cout << "  NNF: " << parser->toString(nnf) << std::endl;
@@ -104,17 +104,17 @@ void test_normal_forms(SOMTParser::ParserPtr& parser) {
         for (const auto& expr : expressions) {
             std::cout << "Expression: " << expr << std::endl;
             std::shared_ptr<SOMTParser::DAGNode> original = parser->mkExpr(expr);
-            assert(original);
+            VERIFY(original);
             std::cout << "  Original: " << parser->toString(original) << std::endl;
             std::shared_ptr<SOMTParser::DAGNode> nnf = parser->toNNF(original);
-            assert(nnf);
+            VERIFY(nnf);
             std::cout << "  NNF: " << parser->toString(nnf) << std::endl;
             std::vector<std::shared_ptr<SOMTParser::DAGNode>> expr_vec = {original};
             std::shared_ptr<SOMTParser::DAGNode> cnf = parser->toCNF(expr_vec);
-            assert(cnf);
+            VERIFY(cnf);
             std::cout << "  CNF: " << parser->toString(cnf) << std::endl;
             std::shared_ptr<SOMTParser::DAGNode> dnf = parser->toDNF(original);
-            assert(dnf);
+            VERIFY(dnf);
             std::cout << "  DNF: " << parser->toString(dnf) << std::endl;
             std::cout << std::endl;
         }
@@ -153,10 +153,10 @@ void test_arithmetic_normalization(SOMTParser::ParserPtr& parser) {
         for (const auto& expr : expressions) {
             std::cout << "Expression: " << expr << std::endl;
             std::shared_ptr<SOMTParser::DAGNode> original = parser->mkExpr(expr);
-            assert(original);
+            VERIFY(original);
             std::cout << "  Original: " << parser->toString(original) << std::endl;
             std::shared_ptr<SOMTParser::DAGNode> normalized = parser->arithNormalize(original);
-            assert(normalized);
+            VERIFY(normalized);
             std::cout << "  Normalized: " << parser->toString(normalized) << std::endl;
             std::cout << std::endl;
         }
@@ -207,10 +207,10 @@ void test_binarization(SOMTParser::ParserPtr& parser) {
         for (const auto& expr : expressions) {
             std::cout << "Expression: " << expr << std::endl;
             std::shared_ptr<SOMTParser::DAGNode> original = parser->mkExpr(expr);
-            assert(original);
+            VERIFY(original);
             std::cout << "  Original: " << parser->toString(original) << std::endl;
             std::shared_ptr<SOMTParser::DAGNode> binarized = parser->binarizeOp(original);
-            assert(binarized);
+            VERIFY(binarized);
             std::cout << "  Binarized: " << parser->toString(binarized) << std::endl;
             std::cout << std::endl;
         }
@@ -252,7 +252,7 @@ void test_collect_atoms_variables(SOMTParser::ParserPtr& parser) {
         for (const auto& expr : expressions) {
             std::cout << "Expression: " << expr << std::endl;
             std::shared_ptr<SOMTParser::DAGNode> formula = parser->mkExpr(expr);
-            assert(formula);
+            VERIFY(formula);
             std::cout << "  Formula: " << parser->toString(formula) << std::endl;
             std::unordered_set<std::shared_ptr<SOMTParser::DAGNode>> atoms;
             parser->collectAtoms(formula, atoms);
@@ -266,7 +266,7 @@ void test_collect_atoms_variables(SOMTParser::ParserPtr& parser) {
             for (const auto& var : vars) {
                 std::cout << "    " << parser->toString(var) << std::endl;
             }
-            assert(atoms.size() > 0 || vars.size() > 0);
+            VERIFY(atoms.size() > 0 || vars.size() > 0);
             std::cout << std::endl;
         }
     } catch (const std::exception& e) {
@@ -296,25 +296,25 @@ void test_substitution(SOMTParser::ParserPtr& parser) {
         
         // Apply substitution
         std::shared_ptr<SOMTParser::DAGNode> substituted = parser->substitute(formula, subst_map);
-        assert(substituted);
+        VERIFY(substituted);
         std::cout << "After substitution {x->5, y->10}: " << parser->toString(substituted) << std::endl;
-        assert(parser->toString(substituted).find("15") != std::string::npos || parser->toString(substituted).find("5") != std::string::npos);
+        VERIFY(parser->toString(substituted).find("15") != std::string::npos || parser->toString(substituted).find("5") != std::string::npos);
         std::unordered_map<std::string, std::shared_ptr<SOMTParser::DAGNode>> subst_map2;
         subst_map2["z"] = parser->mkConstInt(0);
         std::shared_ptr<SOMTParser::DAGNode> substituted2 = parser->substitute(substituted, subst_map2);
-        assert(substituted2);
+        VERIFY(substituted2);
         std::cout << "After substitution {z->0}: " << parser->toString(substituted2) << std::endl;
-    assert(substituted2->isTrue());
+    VERIFY(substituted2->isTrue());
         
         // Create a more complex formula with let
         std::string expr2 = "(let ((a (+ x y))) (> a z))";
         std::shared_ptr<SOMTParser::DAGNode> formula2 = parser->mkExpr(expr2);
-        assert(formula2);
+        VERIFY(formula2);
         std::cout << "Complex formula: " << parser->toString(formula2) << std::endl;
         
         // Apply substitution to complex formula
         std::shared_ptr<SOMTParser::DAGNode> substituted3 = parser->substitute(formula2, subst_map);
-        assert(substituted3);
+        VERIFY(substituted3);
         std::cout << "After substitution {x->5, y->10}: " << parser->toString(substituted3) << std::endl;
 
     } catch (const std::exception& e) {
@@ -344,65 +344,65 @@ void test_collectvars_let_binding(SOMTParser::ParserPtr& parser) {
     // Test 1: (let ((y x)) y) → should find {x}, NOT y
     {
         auto formula = parser->mkExpr("(let ((y x)) y)");
-        assert(formula);
+        VERIFY(formula);
         std::unordered_set<std::shared_ptr<SOMTParser::DAGNode>> vars;
         parser->collectVars(formula, vars);
         auto names = getVarNames(vars);
         std::cout << "  Test 1 vars: ";
         for (const auto& n : names) std::cout << n << " ";
         std::cout << std::endl;
-        assert(names.size() == 1);
-        assert(names.find("x") != names.end());
-        assert(names.find("y") == names.end());
+        VERIFY(names.size() == 1);
+        VERIFY(names.find("x") != names.end());
+        VERIFY(names.find("y") == names.end());
     }
 
     // Test 2: (let ((a b) (c d)) (+ a c)) → should find {b, d}
     {
         auto formula = parser->mkExpr("(let ((a b) (c d)) (+ a c))");
-        assert(formula);
+        VERIFY(formula);
         std::unordered_set<std::shared_ptr<SOMTParser::DAGNode>> vars;
         parser->collectVars(formula, vars);
         auto names = getVarNames(vars);
         std::cout << "  Test 2 vars: ";
         for (const auto& n : names) std::cout << n << " ";
         std::cout << std::endl;
-        assert(names.size() == 2);
-        assert(names.find("b") != names.end());
-        assert(names.find("d") != names.end());
-        assert(names.find("a") == names.end());
-        assert(names.find("c") == names.end());
+        VERIFY(names.size() == 2);
+        VERIFY(names.find("b") != names.end());
+        VERIFY(names.find("d") != names.end());
+        VERIFY(names.find("a") == names.end());
+        VERIFY(names.find("c") == names.end());
     }
 
     // Test 3: Nested let: (let ((y x)) (let ((z y)) z)) → should find {x}
     {
         auto formula = parser->mkExpr("(let ((y x)) (let ((z y)) z))");
-        assert(formula);
+        VERIFY(formula);
         std::unordered_set<std::shared_ptr<SOMTParser::DAGNode>> vars;
         parser->collectVars(formula, vars);
         auto names = getVarNames(vars);
         std::cout << "  Test 3 vars: ";
         for (const auto& n : names) std::cout << n << " ";
         std::cout << std::endl;
-        assert(names.size() == 1);
-        assert(names.find("x") != names.end());
-        assert(names.find("y") == names.end());
-        assert(names.find("z") == names.end());
+        VERIFY(names.size() == 1);
+        VERIFY(names.find("x") != names.end());
+        VERIFY(names.find("y") == names.end());
+        VERIFY(names.find("z") == names.end());
     }
 
     // Test 4: Let with expression: (let ((v (+ p q))) v) → should find {p, q}
     {
         auto formula = parser->mkExpr("(let ((v (+ p q))) v)");
-        assert(formula);
+        VERIFY(formula);
         std::unordered_set<std::shared_ptr<SOMTParser::DAGNode>> vars;
         parser->collectVars(formula, vars);
         auto names = getVarNames(vars);
         std::cout << "  Test 4 vars: ";
         for (const auto& n : names) std::cout << n << " ";
         std::cout << std::endl;
-        assert(names.size() == 2);
-        assert(names.find("p") != names.end());
-        assert(names.find("q") != names.end());
-        assert(names.find("v") == names.end());
+        VERIFY(names.size() == 2);
+        VERIFY(names.find("p") != names.end());
+        VERIFY(names.find("q") != names.end());
+        VERIFY(names.find("v") == names.end());
     }
 
     std::cout << "  test_collectvars_let_binding: all assertions passed" << std::endl;

--- a/test/parser/test_parse_model.cpp
+++ b/test/parser/test_parse_model.cpp
@@ -1,7 +1,7 @@
 #include "somtparser/frontend/parser.h"
 #include <iostream>
 #include <string>
-#include <cassert>
+#include "test_helpers.h"
 
 int main() {
     // Create parser
@@ -1245,78 +1245,78 @@ int main() {
         parser->mkVarInt("x");
         parser->mkVarInt("y");
         auto phi = parser->mkExpr("(and (> x 0) (> y 0))");
-        assert(phi);
+        VERIFY(phi);
         std::string modelStr = R"(
 (model
   (define-fun x () Int 1)
   (define-fun y () Int 2)
 ))";
         auto M = parser->parseModel(modelStr);
-        assert(M && M->size() >= 2);
+        VERIFY(M && M->size() >= 2);
         auto psi = parser->evaluate(phi, M);
-        assert(psi && psi->isTrue() && "evaluate((and (> x 0) (> y 0)), M) with x=1,y=2 should be true");
+        VERIFY(psi && psi->isTrue() && "evaluate((and (> x 0) (> y 0)), M) with x=1,y=2 should be true");
         std::cout << "Basic parseModel + evaluate: phi=(and (> x 0) (> y 0)), M={x->1,y->2} => " << parser->toString(psi) << " OK" << std::endl;
     }
 
     try {
         auto model = parser->parseModel(model_str1);
-        assert(model && "model1 should parse successfully");
+        VERIFY(model && "model1 should parse successfully");
         std::cout << "Model 1 parsed successfully!" << std::endl;
         std::cout << "Model 1 size: " << model->size() << std::endl;
-        assert(model->size() > 0);
+        VERIFY(model->size() > 0);
         auto pairs = model->getPairs();
         for (const auto& pair : pairs) {
             std::cout << "Variable: " << pair.first << " = " << parser->toString(pair.second) << std::endl;
         }
-        assert(pairs.size() == model->size());
+        VERIFY(pairs.size() == model->size());
     } catch (const std::exception& e) {
         std::cout << "Exception during parsing: " << e.what() << std::endl;
-        assert(false && "model1 should not throw");
+        VERIFY(false && "model1 should not throw");
     }
 
     try {
         auto model = parser->parseModel(model_str2);
-        assert(model && "model2 should parse successfully");
+        VERIFY(model && "model2 should parse successfully");
         std::cout << "Model 2 parsed successfully!" << std::endl;
         std::cout << "Model 2 size: " << model->size() << std::endl;
-        assert(model->size() > 0);
+        VERIFY(model->size() > 0);
         auto pairs = model->getPairs();
         for (const auto& pair : pairs) {
             std::cout << "Variable: " << pair.first << " = " << parser->toString(pair.second) << std::endl;
         }
     } catch (const std::exception& e) {
         std::cout << "Exception during parsing: " << e.what() << std::endl;
-        assert(false && "model2 should not throw");
+        VERIFY(false && "model2 should not throw");
     }
 
     try {
         auto model = parser->parseModel(model_str3_simple);
-        assert(model && "model3 (simple as-array) should parse successfully");
+        VERIFY(model && "model3 (simple as-array) should parse successfully");
         std::cout << "Model 3 (simplified) parsed successfully!" << std::endl;
         std::cout << "Model 3 size: " << model->size() << std::endl;
-        assert(model->size() >= 1);
+        VERIFY(model->size() >= 1);
         auto pairs = model->getPairs();
         for (const auto& pair : pairs) {
             std::cout << "Variable: " << pair.first << " = " << parser->toString(pair.second) << std::endl;
         }
     } catch (const std::exception& e) {
         std::cout << "Exception during parsing: " << e.what() << std::endl;
-        assert(false && "model3 should not throw");
+        VERIFY(false && "model3 should not throw");
     }
 
     try {
         auto model = parser->parseModel(model_str4_smtrat);
-        assert(model && "model4 (smtrat) should parse successfully");
+        VERIFY(model && "model4 (smtrat) should parse successfully");
         std::cout << "Model 4 (smtrat) parsed successfully!" << std::endl;
         std::cout << "Model 4 size: " << model->size() << std::endl;
-        assert(model->size() >= 3);
+        VERIFY(model->size() >= 3);
         auto pairs = model->getPairs();
         for (const auto& pair : pairs) {
             std::cout << "Variable: " << pair.first << " = " << parser->toString(pair.second) << std::endl;
         }
     } catch (const std::exception& e) {
         std::cout << "Exception during parsing: " << e.what() << std::endl;
-        assert(false && "model4 should not throw");
+        VERIFY(false && "model4 should not throw");
     }
 
     try {
@@ -1329,10 +1329,10 @@ int main() {
         
         auto model = parser->parseModel(model_str5_cvc5);
         
-        assert(model && "model5 (CVC5 real_algebraic_number) should parse successfully");
+        VERIFY(model && "model5 (CVC5 real_algebraic_number) should parse successfully");
         std::cout << "Model 5 (CVC5 real_algebraic_number) parsed successfully!" << std::endl;
         std::cout << "Model 5 size: " << model->size() << std::endl;
-        assert(model->size() == 1);
+        VERIFY(model->size() == 1);
         auto pairs = model->getPairs();
         for (const auto& pair : pairs) {
             std::cout << "Variable: " << pair.first << " = " << parser->toString(pair.second) << std::endl;
@@ -1345,7 +1345,7 @@ int main() {
         }
     } catch (const std::exception& e) {
         std::cout << "Exception during parsing: " << e.what() << std::endl;
-        assert(false && "model5 should not throw");
+        VERIFY(false && "model5 should not throw");
     }
     return 0;
 }

--- a/test/parser/test_parse_oper_builtin_priority.cpp
+++ b/test/parser/test_parse_oper_builtin_priority.cpp
@@ -2,45 +2,45 @@
 #include "somtparser/ir/dag.h"
 #include "somtparser/ir/sort.h"
 #include "somtparser/model/model.h"
-#include <cassert>
 #include <iostream>
+#include "test_helpers.h"
 
 // Issue 1 regression: indexed (_ op ...) uses builtin NODE_KIND (reserved names cannot be declare-fun).
 int main() {
     using namespace SOMTParser;
 
     ParserPtr p = newParser();
-    assert(p->parseStr("(set-logic ALL)"));
+    VERIFY(p->parseStr("(set-logic ALL)"));
 
     p->mkVarInt("x");
     {
         auto e = p->mkExpr("(_ to_real x)");
-        assert(e && !e->isErr());
-        assert(e->getKind() == NODE_KIND::NT_TO_REAL);
-        assert(e->isToReal());
+        VERIFY(e && !e->isErr());
+        VERIFY(e->getKind() == NODE_KIND::NT_TO_REAL);
+        VERIFY(e->isToReal());
     }
 
     // Note: do not use (_ bvadd ...): the "_" fast-path treats "bv*" as (_ bvNN width) literals.
     {
         auto e = p->mkExpr("(_ abs x)");
-        assert(e && !e->isErr());
-        assert(e->getKind() == NODE_KIND::NT_ABS);
+        VERIFY(e && !e->isErr());
+        VERIFY(e->getKind() == NODE_KIND::NT_ABS);
     }
 
     {
         ParserPtr p = newParser();
-        assert(p->parseStr("(set-logic ALL)"));
+        VERIFY(p->parseStr("(set-logic ALL)"));
         auto px = p->mkFunParamVar(SortManager::INT_SORT, "x");
         p->getSymbolManager()->registerFunVar("x", px);
         auto body = p->mkExpr("(ite (= x 0) 5 0)");
         p->getSymbolManager()->eraseFunVar("x");
         auto fd = p->mkFuncDef("f_issue2", {px}, SortManager::INT_SORT, body);
-        assert(fd && !fd->isErr());
+        VERIFY(fd && !fd->isErr());
         auto app = p->mkExpr("(f_issue2 0)");
-        assert(app && app->isFuncApplication());
+        VERIFY(app && app->isFuncApplication());
         ModelPtr m = newModel();
         auto r = p->evaluate(app, m);
-        assert(r && p->toString(r) == "5");
+        VERIFY(r && p->toString(r) == "5");
     }
 
     std::cout << "test_parse_oper_builtin_priority: ok\n";

--- a/test/parser/test_parser.cpp
+++ b/test/parser/test_parser.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <string>
 #include "somtparser/frontend/parser.h"
-#include <cassert>
+#include "test_helpers.h"
 
 int main() {
     std::cout << "======= SOMTParser Test Program =======" << std::endl;
@@ -10,7 +10,7 @@ int main() {
     {
         SOMTParser::ParserPtr parser = SOMTParser::newParser();
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr("true");
-        assert(result && result->isTrue() && !result->isFalse());
+        VERIFY(result && result->isTrue() && !result->isFalse());
         std::cout << "Input: true" << std::endl;
         std::cout << "Result: " << parser->toString(result) << std::endl;
         std::cout << "isTrue: yes" << std::endl;
@@ -18,7 +18,7 @@ int main() {
     {
         SOMTParser::ParserPtr parser = SOMTParser::newParser();
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr("false");
-        assert(result && result->isFalse() && !result->isTrue());
+        VERIFY(result && result->isFalse() && !result->isTrue());
         std::cout << "Input: false" << std::endl;
         std::cout << "Result: " << parser->toString(result) << std::endl;
         std::cout << "isFalse: yes" << std::endl;
@@ -28,7 +28,7 @@ int main() {
     {
         SOMTParser::ParserPtr parser = SOMTParser::newParser();
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr("42");
-        assert(result && parser->toString(result) == "42");
+        VERIFY(result && parser->toString(result) == "42");
         std::cout << "Input: 42" << std::endl;
         std::cout << "Result: " << parser->toString(result) << std::endl;
     }
@@ -37,7 +37,7 @@ int main() {
     {
         SOMTParser::ParserPtr parser = SOMTParser::newParser();
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr("3.14");
-        assert(result && result->isCReal() &&
+        VERIFY(result && result->isCReal() &&
                parser->toString(result) == "(/ 157 50)");
         std::cout << "Input: 3.14" << std::endl;
         std::cout << "Result: " << parser->toString(result) << std::endl;
@@ -47,7 +47,7 @@ int main() {
     {
         SOMTParser::ParserPtr parser = SOMTParser::newParser();
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr("(and true false)");
-        assert(result && result->isFalse());
+        VERIFY(result && result->isFalse());
         std::cout << "Input: (and true false)" << std::endl;
         std::cout << "Result: " << parser->toString(result) << std::endl;
     }

--- a/test/regression/test_error.cpp
+++ b/test/regression/test_error.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <string>
 #include "somtparser/frontend/parser.h"
-#include <cassert>
+#include "test_helpers.h"
 
 int main() {
     std::cout << "======= Parser Error Test =======" << std::endl;
@@ -65,7 +65,7 @@ int main() {
 (check-sat)
 (get-model)
 )");
-        assert(ok && "error_kind_mismatch should parse");
+        VERIFY(ok && "error_kind_mismatch should parse");
         std::cout << "Test 1 passed: error_kind_mismatch\n";
     }
 
@@ -86,7 +86,7 @@ int main() {
 (get-unsat-core)
 (exit)
 )");
-        assert(ok && "error_unknown_symbol should parse");
+        VERIFY(ok && "error_unknown_symbol should parse");
         std::cout << "Test 2 passed: error_unknown_symbol\n";
     }
 
@@ -104,7 +104,7 @@ int main() {
 (check-sat)
 (exit)
 )");
-        assert(ok && "error_unknown_symbol_2 should parse");
+        VERIFY(ok && "error_unknown_symbol_2 should parse");
         std::cout << "Test 3 passed: error_unknown_symbol_2\n";
     }
 

--- a/test/regression/test_issue1_4_7.cpp
+++ b/test/regression/test_issue1_4_7.cpp
@@ -8,8 +8,8 @@
 #include "somtparser/frontend/parser.h"
 #include "somtparser/ir/number.h"
 #include "somtparser/ir/value.h"
-#include <cassert>
 #include <iostream>
+#include "test_helpers.h"
 
 using SOMTParser::NODE_KIND;
 using SOMTParser::ParserPtr;
@@ -17,36 +17,36 @@ using SOMTParser::SortManager;
 
 static void test_issue1_reserved_and_ge_kind(ParserPtr& p) {
     std::cout << "=== Issue 1: reserved built-ins and (>= ...) kind ===" << std::endl;
-    assert(SOMTParser::isBuiltinNameReservedAgainstUserFun(">="));
-    assert(!SOMTParser::builtinOperMayBeShadowedByUserFun(">="));
-    assert(!SOMTParser::isBuiltinNameReservedAgainstUserFun("factorial"));
+    VERIFY(SOMTParser::isBuiltinNameReservedAgainstUserFun(">="));
+    VERIFY(!SOMTParser::builtinOperMayBeShadowedByUserFun(">="));
+    VERIFY(!SOMTParser::isBuiltinNameReservedAgainstUserFun("factorial"));
 
     auto ok = p->mkFuncDec("factorial", {SortManager::INT_SORT}, SortManager::INT_SORT);
-    assert(!ok->isUnknown() && !ok->isErr());
+    VERIFY(!ok->isUnknown() && !ok->isErr());
 
     p->mkVarInt("x");
     p->mkVarInt("y");
     auto ge = p->mkExpr("(>= x y)");
-    assert(ge && ge->isGe());
-    assert(p->getKind(">=") == NODE_KIND::NT_GE);
+    VERIFY(ge && ge->isGe());
+    VERIFY(p->getKind(">=") == NODE_KIND::NT_GE);
 }
 
 static void test_issue7_bv_utils_not_get_number_value(ParserPtr& p) {
     std::cout << "=== Issue 7: BV literal + BitVectorUtils (getNumberValue is NUMBER-only) ===" << std::endl;
     auto n = p->mkExpr("(_ bv42 8)");
-    assert(n && n->isCBV());
+    VERIFY(n && n->isCBV());
     auto v = n->getValue();
-    assert(v && v->getType() == SOMTParser::BV);
-    assert(SOMTParser::BitVectorUtils::bvToNat(n->toString()) == SOMTParser::Integer(42));
+    VERIFY(v && v->getType() == SOMTParser::BV);
+    VERIFY(SOMTParser::BitVectorUtils::bvToNat(n->toString()) == SOMTParser::Integer(42));
 }
 
 static void test_issue4_fp_const_get_value(ParserPtr& p) {
     std::cout << "=== Issue 4: FP const getValue after mkConstFp path ===" << std::endl;
     auto n = p->mkExpr("((_ to_fp 8 24) RNE 1.0)");
-    assert(n && !n->isErr() && n->isCFP());
+    VERIFY(n && !n->isErr() && n->isCFP());
     auto val = n->getValue();
-    assert(val != nullptr);
-    assert(val->getType() == SOMTParser::FP);
+    VERIFY(val != nullptr);
+    VERIFY(val->getType() == SOMTParser::FP);
 }
 
 // ─── Issue #2: Sort-classified variable accessors ────────────────────────────
@@ -62,10 +62,10 @@ static void test_issue2_sort_classified_vars() {
         ParserPtr p = SOMTParser::newParser();
         p->mkVarBool("b1");
         p->mkVarBool("b2");
-        assert(p->getNumBoolVars() == 2);
-        assert(p->getBoolVars().size() == 2);
-        assert(p->getNumIntVars() == 0);
-        assert(p->getNumFpVars() == 0);
+        VERIFY(p->getNumBoolVars() == 2);
+        VERIFY(p->getBoolVars().size() == 2);
+        VERIFY(p->getNumIntVars() == 0);
+        VERIFY(p->getNumFpVars() == 0);
         std::cout << "  Bool vars: OK\n";
     }
 
@@ -75,9 +75,9 @@ static void test_issue2_sort_classified_vars() {
         p->mkVarInt("i1");
         p->mkVarInt("i2");
         p->mkVarInt("i3");
-        assert(p->getNumIntVars() == 3);
-        assert(p->getNumBoolVars() == 0);
-        assert(p->getNumRealVars() == 0);
+        VERIFY(p->getNumIntVars() == 3);
+        VERIFY(p->getNumBoolVars() == 0);
+        VERIFY(p->getNumRealVars() == 0);
         std::cout << "  Int vars: OK\n";
     }
 
@@ -85,8 +85,8 @@ static void test_issue2_sort_classified_vars() {
     {
         ParserPtr p = SOMTParser::newParser();
         p->mkVarReal("r1");
-        assert(p->getNumRealVars() == 1);
-        assert(p->getNumIntVars() == 0);
+        VERIFY(p->getNumRealVars() == 1);
+        VERIFY(p->getNumIntVars() == 0);
         std::cout << "  Real vars: OK\n";
     }
 
@@ -95,8 +95,8 @@ static void test_issue2_sort_classified_vars() {
         ParserPtr p = SOMTParser::newParser();
         p->mkVarBv("bv1", 32);
         p->mkVarBv("bv2", 8);
-        assert(p->getNumBvVars() == 2);
-        assert(p->getNumBoolVars() == 0);
+        VERIFY(p->getNumBvVars() == 2);
+        VERIFY(p->getNumBoolVars() == 0);
         std::cout << "  BV vars: OK\n";
     }
 
@@ -105,9 +105,9 @@ static void test_issue2_sort_classified_vars() {
         ParserPtr p = SOMTParser::newParser();
         p->mkVarFp("fp1", 8, 24);   // Float32
         p->mkVarFp("fp2", 11, 53);  // Float64
-        assert(p->getNumFpVars() == 2);
-        assert(p->getFpVars().size() == 2);
-        assert(p->getNumBvVars() == 0);
+        VERIFY(p->getNumFpVars() == 2);
+        VERIFY(p->getFpVars().size() == 2);
+        VERIFY(p->getNumBvVars() == 0);
         std::cout << "  FP vars: OK\n";
     }
 
@@ -115,8 +115,8 @@ static void test_issue2_sort_classified_vars() {
     {
         ParserPtr p = SOMTParser::newParser();
         p->mkVarRoundingMode("rm1");
-        assert(p->getNumRoundingModeVars() == 1);
-        assert(p->getNumFpVars() == 0);
+        VERIFY(p->getNumRoundingModeVars() == 1);
+        VERIFY(p->getNumFpVars() == 0);
         std::cout << "  RoundingMode vars: OK\n";
     }
 
@@ -130,13 +130,13 @@ static void test_issue2_sort_classified_vars() {
             "(declare-fun r () Real)\n"
             "(declare-fun fp32 () (_ FloatingPoint 8 24))\n"
             "(declare-fun bv16 () (_ BitVec 16))\n");
-        assert(p->getNumBoolVars() == 1);
-        assert(p->getNumIntVars()  == 1);
-        assert(p->getNumRealVars() == 1);
-        assert(p->getNumFpVars()   == 1);
-        assert(p->getNumBvVars()   == 1);
+        VERIFY(p->getNumBoolVars() == 1);
+        VERIFY(p->getNumIntVars()  == 1);
+        VERIFY(p->getNumRealVars() == 1);
+        VERIFY(p->getNumFpVars()   == 1);
+        VERIFY(p->getNumBvVars()   == 1);
         // Total through getDeclaredVariables
-        assert(p->getDeclaredVariables().size() == 5);
+        VERIFY(p->getDeclaredVariables().size() == 5);
         std::cout << "  Mixed problem variable classification: OK\n";
     }
 
@@ -147,8 +147,8 @@ static void test_issue2_sort_classified_vars() {
             "(set-logic QF_S)\n"
             "(declare-fun s1 () String)\n"
             "(declare-fun s2 () String)\n");
-        assert(p->getNumStringVars() == 2);
-        assert(p->getNumBoolVars() == 0);
+        VERIFY(p->getNumStringVars() == 2);
+        VERIFY(p->getNumBoolVars() == 0);
         std::cout << "  String vars: OK\n";
     }
 
@@ -160,8 +160,8 @@ static void test_issue2_sort_classified_vars() {
             "(declare-datatypes ((Color 0)) (((red) (green) (blue))))\n"
             "(declare-fun c1 () Color)\n"
             "(declare-fun c2 () Color)\n");
-        assert(p->getNumDatatypeVars() == 2);
-        assert(p->getNumBoolVars() == 0);
+        VERIFY(p->getNumDatatypeVars() == 2);
+        VERIFY(p->getNumBoolVars() == 0);
         std::cout << "  Datatype vars: OK\n";
     }
 

--- a/test/test_helpers.h
+++ b/test/test_helpers.h
@@ -5,6 +5,15 @@
 #include <iostream>
 #include <string>
 
+// The test targets are compiled with -UNDEBUG (see test/CMakeLists.txt) so that
+// assert() keeps working under the default Release build type, which defines
+// NDEBUG. If that flag is ever lost, every assert() in the suite silently stops
+// checking -- and any whose expression does the work being tested stops running
+// at all. Fail the build instead of losing coverage quietly.
+#ifdef NDEBUG
+#error "Tests must be built with assertions enabled; test/CMakeLists.txt is expected to pass -UNDEBUG."
+#endif
+
 // NDEBUG-safe assertion for side-effectful expressions.
 // Unlike <cassert>'s assert(), this always evaluates the expression even under NDEBUG.
 #define VERIFY(expr) do { \

--- a/test/theory/test_arithmetic.cpp
+++ b/test/theory/test_arithmetic.cpp
@@ -4,7 +4,7 @@
 #include "somtparser/core/kind.h"
 #include "somtparser/frontend/parser.h"
 #include "somtparser/ir/number.h"
-#include <cassert>
+#include "test_helpers.h"
 
 using SOMTParser::SortManager;
 
@@ -25,11 +25,11 @@ void test_integer_arithmetic(SOMTParser::ParserPtr& parser) {
     for (const auto& p : cases) {
         std::cout << "Expression: " << p.first << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(p.first);
-        assert(result);
+        VERIFY(result);
         std::string got = parser->toString(result);
         std::cout << "  Result: " << got << std::endl;
         auto expected = parser->mkExpr(p.second);
-        assert(expected && parser->toString(result) == parser->toString(expected) &&
+        VERIFY(expected && parser->toString(result) == parser->toString(expected) &&
                "integer arithmetic result mismatch");
         std::cout << std::endl;
     }
@@ -53,11 +53,11 @@ void test_real_arithmetic(SOMTParser::ParserPtr& parser) {
     for (const auto& p : cases) {
         std::cout << "Expression: " << p.first << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(p.first);
-        assert(result);
+        VERIFY(result);
         std::string got = parser->toString(result);
         std::cout << "  Result: " << got << std::endl;
         auto expected = parser->mkExpr(p.second);
-        assert(expected && parser->toString(result) == parser->toString(expected) &&
+        VERIFY(expected && parser->toString(result) == parser->toString(expected) &&
                "real arithmetic result mismatch");
         std::cout << std::endl;
     }
@@ -78,9 +78,9 @@ void test_comparisons(SOMTParser::ParserPtr& parser) {
     for (const auto& p : cases) {
         std::cout << "Expression: " << p.first << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(p.first);
-        assert(result);
+        VERIFY(result);
         std::cout << "  Result: " << parser->toString(result) << std::endl;
-        assert(result->isTrue() == p.second && "comparison should evaluate to expected bool");
+        VERIFY(result->isTrue() == p.second && "comparison should evaluate to expected bool");
         std::cout << std::endl;
     }
 }
@@ -92,14 +92,14 @@ void test_precision(SOMTParser::ParserPtr& parser) {
     std::cout << "=== Default Precision (128 bits) ===" << std::endl;
     auto r1 = parser->mkExpr("(+ 3.5 2.7)");
     auto r2 = parser->mkExpr("(- 10.5 4.2)");
-    assert(r1 && r2);
+    VERIFY(r1 && r2);
     std::cout << "Expression: (+ 3.5 2.7)" << std::endl;
     std::cout << "  Result: " << parser->toString(r1) << std::endl;
-    assert(r1->getValue()->getNumberValue().toRationalExact() ==
+    VERIFY(r1->getValue()->getNumberValue().toRationalExact() ==
            SOMTParser::Rational("31/5"));
     std::cout << "Expression: (- 10.5 4.2)" << std::endl;
     std::cout << "  Result: " << parser->toString(r2) << std::endl;
-    assert(r2->getValue()->getNumberValue().toRationalExact() ==
+    VERIFY(r2->getValue()->getNumberValue().toRationalExact() ==
            SOMTParser::Rational("63/10"));
     
     // Set higher precision (256 bits)
@@ -107,14 +107,14 @@ void test_precision(SOMTParser::ParserPtr& parser) {
     std::cout << "\n=== Higher Precision (256 bits) ===" << std::endl;
     auto r3 = parser->mkExpr("(+ 3.5 2.7)");
     auto r4 = parser->mkExpr("(- 10.5 4.2)");
-    assert(r3 && r4);
+    VERIFY(r3 && r4);
     std::cout << "Expression: (+ 3.5 2.7)" << std::endl;
     std::cout << "  Result: " << parser->toString(r3) << std::endl;
     std::cout << "Expression: (- 10.5 4.2)" << std::endl;
     std::cout << "  Result: " << parser->toString(r4) << std::endl;
-    assert(r3->getValue()->getNumberValue().toRationalExact() ==
+    VERIFY(r3->getValue()->getNumberValue().toRationalExact() ==
            SOMTParser::Rational("31/5"));
-    assert(r4->getValue()->getNumberValue().toRationalExact() ==
+    VERIFY(r4->getValue()->getNumberValue().toRationalExact() ==
            SOMTParser::Rational("63/10"));
     
     // Disable floating point mode
@@ -122,29 +122,29 @@ void test_precision(SOMTParser::ParserPtr& parser) {
     std::cout << "\n=== Disable Floating Point Mode ===" << std::endl;
     auto r5 = parser->mkExpr("(+ 3.5 2.7)");
     auto r6 = parser->mkExpr("(- 10.5 4.2)");
-    assert(r5 && r6);
+    VERIFY(r5 && r6);
     std::cout << "Expression: (+ 3.5 2.7)" << std::endl;
     std::cout << "  Result: " << parser->toString(r5) << std::endl;
     std::cout << "Expression: (- 10.5 4.2)" << std::endl;
     std::cout << "  Result: " << parser->toString(r6) << std::endl;
-    assert(r5->getValue()->getNumberValue().toRationalExact() ==
+    VERIFY(r5->getValue()->getNumberValue().toRationalExact() ==
            SOMTParser::Rational("31/5"));
-    assert(r6->getValue()->getNumberValue().toRationalExact() ==
+    VERIFY(r6->getValue()->getNumberValue().toRationalExact() ==
            SOMTParser::Rational("63/10"));
 }
 
 static void test_builtin_shadow_pow2_uf(SOMTParser::ParserPtr& p) {
     std::cout << "=== Builtin shadow: pow2 ===" << std::endl;
-    assert(SOMTParser::builtinOperMayBeShadowedByUserFun("pow2"));
-    assert(!SOMTParser::isBuiltinNameReservedAgainstUserFun("pow2"));
+    VERIFY(SOMTParser::builtinOperMayBeShadowedByUserFun("pow2"));
+    VERIFY(!SOMTParser::isBuiltinNameReservedAgainstUserFun("pow2"));
 
     auto fd = p->mkFuncDec("pow2", {SortManager::INT_SORT}, SortManager::INT_SORT);
-    assert(fd && !fd->isUnknown() && !fd->isErr());
+    VERIFY(fd && !fd->isUnknown() && !fd->isErr());
 
     p->mkVarInt("x");
     auto app = p->mkExpr("(pow2 x)");
-    assert(app && !app->isErr());
-    assert(app->isUFApplication());
+    VERIFY(app && !app->isErr());
+    VERIFY(app->isUFApplication());
 }
 
 void test_number_bitwise_operators() {
@@ -152,16 +152,16 @@ void test_number_bitwise_operators() {
     SOMTParser::Number a(SOMTParser::Integer(0b1100));
     SOMTParser::Number b(SOMTParser::Integer(0b1010));
 
-    assert((a & b) == SOMTParser::Number(SOMTParser::Integer(0b1000)));
-    assert((a | b) == SOMTParser::Number(SOMTParser::Integer(0b1110)));
-    assert((a ^ b) == SOMTParser::Number(SOMTParser::Integer(0b0110)));
-    assert(~a == SOMTParser::Number(SOMTParser::Integer(-13)));
+    VERIFY((a & b) == SOMTParser::Number(SOMTParser::Integer(0b1000)));
+    VERIFY((a | b) == SOMTParser::Number(SOMTParser::Integer(0b1110)));
+    VERIFY((a ^ b) == SOMTParser::Number(SOMTParser::Integer(0b0110)));
+    VERIFY(~a == SOMTParser::Number(SOMTParser::Integer(-13)));
 
     SOMTParser::Number c(SOMTParser::Integer(1));
-    assert((c << 3) == SOMTParser::Number(SOMTParser::Integer(8)));
+    VERIFY((c << 3) == SOMTParser::Number(SOMTParser::Integer(8)));
 
     SOMTParser::Number d(SOMTParser::Integer(16));
-    assert((d >> 2) == SOMTParser::Number(SOMTParser::Integer(4)));
+    VERIFY((d >> 2) == SOMTParser::Number(SOMTParser::Integer(4)));
 }
 
 int main() {

--- a/test/theory/test_array_simplify.cpp
+++ b/test/theory/test_array_simplify.cpp
@@ -1,14 +1,13 @@
 #include <iostream>
 #include <string>
 #include <vector>
-#include <cassert>
 #include "somtparser/frontend/parser.h"
+#include "test_helpers.h"
 
 // Restore assert after parser.h may have undefined it
 #ifdef assert
 #undef assert
 #endif
-#include <cassert>
 
 using namespace SOMTParser;
 
@@ -28,7 +27,7 @@ void test_select_rewrite(ParserPtr& parser) {
     std::cout << "  Input: select(store(array, 1, 10), 1)" << std::endl;
     std::cout << "  Output: " << dumpSMTLIB2(select1) << std::endl;
     std::cout << "  Expected: 10" << std::endl;
-    assert(select1->isConst() && select1->getName() == "10");
+    VERIFY(select1->isConst() && select1->getName() == "10");
     std::cout << "  ✓ PASSED" << std::endl;
     
     // Test 2: select(store(array, 1, 10), 2) should simplify to select(array, 2)
@@ -37,7 +36,7 @@ void test_select_rewrite(ParserPtr& parser) {
     std::cout << "  Input: select(store(array, 1, 10), 2)" << std::endl;
     std::cout << "  Output: " << dumpSMTLIB2(select2) << std::endl;
     std::cout << "  Expected: (select ((as const (Array Int Int)) 0) 2)" << std::endl;
-    assert(select2->isSelect());
+    VERIFY(select2->isSelect());
     std::cout << "  ✓ PASSED" << std::endl;
     
     // Test 3: select(store(store(array, 1, 10), 1, 20), 1) should simplify to 20 (latest write wins)
@@ -47,7 +46,7 @@ void test_select_rewrite(ParserPtr& parser) {
     std::cout << "  Input: select(store(store(array, 1, 10), 1, 20), 1)" << std::endl;
     std::cout << "  Output: " << dumpSMTLIB2(select3) << std::endl;
     std::cout << "  Expected: 20" << std::endl;
-    assert(select3->isConst() && select3->getName() == "20");
+    VERIFY(select3->isConst() && select3->getName() == "20");
     std::cout << "  ✓ PASSED" << std::endl;
 }
 
@@ -65,7 +64,7 @@ void test_store_normalize(ParserPtr& parser) {
     auto store2 = parser->mkStore(store1, parser->mkConstInt(2), parser->mkConstInt(20));
     std::cout << "  Input: store(store(array, 1, 10), 2, 20)" << std::endl;
     std::cout << "  Output: " << dumpSMTLIB2(store2) << std::endl;
-    assert(store2->isStore());
+    VERIFY(store2->isStore());
     std::cout << "  ✓ PASSED" << std::endl;
     
     // Test 2: store(store(array, 1, 10), 1, 20) should merge duplicate indices
@@ -74,10 +73,10 @@ void test_store_normalize(ParserPtr& parser) {
     std::cout << "  Input: store(store(array, 1, 10), 1, 20)" << std::endl;
     std::cout << "  Output: " << dumpSMTLIB2(store3) << std::endl;
     std::cout << "  Expected: store(array, 1, 20) (duplicate index merged)" << std::endl;
-    assert(store3->isStore());
+    VERIFY(store3->isStore());
     // Verify that select(store3, 1) gives 20
     auto select_test = parser->mkSelect(store3, parser->mkConstInt(1));
-    assert(select_test->isConst() && select_test->getName() == "20");
+    VERIFY(select_test->isConst() && select_test->getName() == "20");
     std::cout << "  ✓ PASSED" << std::endl;
     
     // Test 3: Complex store chain with multiple updates
@@ -88,7 +87,7 @@ void test_store_normalize(ParserPtr& parser) {
     std::cout << "  Output: " << dumpSMTLIB2(store5) << std::endl;
     // Verify that select(store5, 1) gives 100 (latest write)
     auto select_test2 = parser->mkSelect(store5, parser->mkConstInt(1));
-    assert(select_test2->isConst() && select_test2->getName() == "100");
+    VERIFY(select_test2->isConst() && select_test2->getName() == "100");
     std::cout << "  ✓ PASSED" << std::endl;
 }
 
@@ -111,7 +110,7 @@ void test_array_output_format(ParserPtr& parser) {
     std::cout << "  Expected format: (store (store (store ...) ...) ...)" << std::endl;
     
     // Verify output contains store operations
-    assert(output.find("store") != std::string::npos);
+    VERIFY(output.find("store") != std::string::npos);
     std::cout << "  ✓ PASSED" << std::endl;
 }
 
@@ -135,7 +134,7 @@ void test_integration_with_normalize(ParserPtr& parser) {
     std::cout << "  Expected: 20" << std::endl;
     
     // The select should be simplified to 20
-    assert(normalized->isConst() && normalized->getName() == "20");
+    VERIFY(normalized->isConst() && normalized->getName() == "20");
     std::cout << "  ✓ PASSED" << std::endl;
 }
 
@@ -155,7 +154,7 @@ void test_evaluate_array(ParserPtr& parser) {
     std::cout << "  Input: select((as const (Array Int Int)) 0, 1)" << std::endl;
     std::cout << "  Evaluated: " << dumpSMTLIB2(eval_result1) << std::endl;
     std::cout << "  Expected: (select ((as const (Array Int Int)) 0) 1)" << std::endl;
-    assert(eval_result1->isSelect());
+    VERIFY(eval_result1->isSelect());
     std::cout << "  ✓ PASSED" << std::endl;
     
     // Test 2: Evaluate select(store(...), index) - should use simplification
@@ -166,7 +165,7 @@ void test_evaluate_array(ParserPtr& parser) {
     std::cout << "  Input: select(store(array, 1, 10), 1)" << std::endl;
     std::cout << "  Evaluated: " << dumpSMTLIB2(eval_result2) << std::endl;
     std::cout << "  Expected: 10 (simplified by rewriteSelect)" << std::endl;
-    assert(eval_result2->isConst() && eval_result2->getName() == "10");
+    VERIFY(eval_result2->isConst() && eval_result2->getName() == "10");
     std::cout << "  ✓ PASSED" << std::endl;
     
     // Test 3: Evaluate store with model containing array variable
@@ -186,7 +185,7 @@ void test_evaluate_array(ParserPtr& parser) {
     std::cout << "  Input: store(arr, 1, 20) where arr = store(array, 0, 5)" << std::endl;
     std::cout << "  Evaluated: " << dumpSMTLIB2(eval_result3) << std::endl;
     // Note: The output may still contain 'arr' if evaluate doesn't replace it, but the store structure should be correct
-    assert(eval_result3->isStore());
+    VERIFY(eval_result3->isStore());
     std::cout << "  ✓ PASSED" << std::endl;
     
     // Test 4: Evaluate select with array variable in model
@@ -202,7 +201,7 @@ void test_evaluate_array(ParserPtr& parser) {
     } else {
         std::cout << "  Note: Variable not replaced in evaluate, but structure is correct" << std::endl;
     }
-    assert(eval_result4->isSelect() || (eval_result4->isConst() && eval_result4->getName() == "5"));
+    VERIFY(eval_result4->isSelect() || (eval_result4->isConst() && eval_result4->getName() == "5"));
     std::cout << "  ✓ PASSED" << std::endl;
     
     // Test 5: Evaluate select with index variable in model
@@ -214,7 +213,7 @@ void test_evaluate_array(ParserPtr& parser) {
     std::cout << "  Input: select(store(array, 1, 10), idx) where idx = 1" << std::endl;
     std::cout << "  Evaluated: " << dumpSMTLIB2(eval_result5) << std::endl;
     std::cout << "  Expected: 10 (simplified)" << std::endl;
-    assert(eval_result5->isConst() && eval_result5->getName() == "10");
+    VERIFY(eval_result5->isConst() && eval_result5->getName() == "10");
     std::cout << "  ✓ PASSED" << std::endl;
     
     // Test 6: Evaluate complex store chain with model
@@ -226,7 +225,7 @@ void test_evaluate_array(ParserPtr& parser) {
     std::cout << "  Input: select(store(store(store(array, 1, 10), 2, 30), 1, 100), 1)" << std::endl;
     std::cout << "  Evaluated: " << dumpSMTLIB2(eval_result6) << std::endl;
     std::cout << "  Expected: 100 (latest write wins)" << std::endl;
-    assert(eval_result6->isConst() && eval_result6->getName() == "100");
+    VERIFY(eval_result6->isConst() && eval_result6->getName() == "100");
     std::cout << "  ✓ PASSED" << std::endl;
 }
 
@@ -247,7 +246,7 @@ void test_array_equality(ParserPtr& parser) {
     std::cout << "  Expected: true" << std::endl;
     // After simplification, should be true
     auto eq1_simp = parser->arithNormalize(eq1);
-    assert(eq1_simp->isTrue());
+    VERIFY(eq1_simp->isTrue());
     std::cout << "  ✓ PASSED" << std::endl;
     
     // Test 2: Two different const arrays should not be equal
@@ -258,7 +257,7 @@ void test_array_equality(ParserPtr& parser) {
     std::cout << "  Output: " << dumpSMTLIB2(eq2) << std::endl;
     std::cout << "  Expected: false" << std::endl;
     auto eq2_simp = parser->arithNormalize(eq2);
-    assert(eq2_simp->isFalse());
+    VERIFY(eq2_simp->isFalse());
     std::cout << "  ✓ PASSED" << std::endl;
     
     // Test 3: store(const_array, i, v) = store(const_array, i, v) (same writes)
@@ -270,7 +269,7 @@ void test_array_equality(ParserPtr& parser) {
     std::cout << "  Output: " << dumpSMTLIB2(eq3) << std::endl;
     std::cout << "  Expected: true" << std::endl;
     auto eq3_simp = parser->arithNormalize(eq3);
-    assert(eq3_simp->isTrue());
+    VERIFY(eq3_simp->isTrue());
     std::cout << "  ✓ PASSED" << std::endl;
     
     // Test 4: store(const_array, i, v1) = store(const_array, i, v2) (different values)
@@ -281,7 +280,7 @@ void test_array_equality(ParserPtr& parser) {
     std::cout << "  Output: " << dumpSMTLIB2(eq4) << std::endl;
     std::cout << "  Expected: false" << std::endl;
     auto eq4_simp = parser->arithNormalize(eq4);
-    assert(eq4_simp->isFalse());
+    VERIFY(eq4_simp->isFalse());
     std::cout << "  ✓ PASSED" << std::endl;
     
     // Test 5: store(store(const_array, 1, 10), 1, 20) = store(const_array, 1, 20) (duplicate index merged)
@@ -293,7 +292,7 @@ void test_array_equality(ParserPtr& parser) {
     std::cout << "  Output: " << dumpSMTLIB2(eq5) << std::endl;
     std::cout << "  Expected: true (duplicate index merged in canonical form)" << std::endl;
     auto eq5_simp = parser->arithNormalize(eq5);
-    assert(eq5_simp->isTrue());
+    VERIFY(eq5_simp->isTrue());
     std::cout << "  ✓ PASSED" << std::endl;
     
     // Test 6: store(const_array, i, base_value) = const_array (semantically equal but structurally different)
@@ -302,7 +301,7 @@ void test_array_equality(ParserPtr& parser) {
     auto store6 = parser->mkStore(const_array, parser->mkConstInt(1), parser->mkConstInt(0));
     std::cout << "  store6->isStore(): " << (store6->isStore() ? "true" : "false") << std::endl;
     std::cout << "  store6->isConstArray(): " << (store6->isConstArray() ? "true" : "false") << std::endl;
-    assert(store6->isStore() && !store6->isConstArray());  // Store operation creates a store node, not const array
+    VERIFY(store6->isStore() && !store6->isConstArray());  // Store operation creates a store node, not const array
     
     auto eq6 = parser->mkEq(store6, const_array);
     std::cout << "  Input: (= store(const_array(0), 1, 0) const_array(0))" << std::endl;
@@ -311,16 +310,16 @@ void test_array_equality(ParserPtr& parser) {
     auto eq6_simp = parser->arithNormalize(eq6);
     // According to extensional equality, if all writes equal base, they are equal
     // But structurally, store6 is not a const array (it's a store node)
-    assert(eq6_simp->isTrue());
+    VERIFY(eq6_simp->isTrue());
     std::cout << "  ✓ PASSED (structurally different but semantically equal)" << std::endl;
     
     // Test 6b: Multiple stores with same value as base
     std::cout << "\nTest 6b: store(store(const_array(0), 1, 0), 2, 0) = const_array(0)" << std::endl;
     auto store6b = parser->mkStore(store6, parser->mkConstInt(2), parser->mkConstInt(0));
-    assert(store6b->isStore() && !store6b->isConstArray());
+    VERIFY(store6b->isStore() && !store6b->isConstArray());
     auto eq6b = parser->mkEq(store6b, const_array);
     auto eq6b_simp = parser->arithNormalize(eq6b);
-    assert(eq6b_simp->isTrue());
+    VERIFY(eq6b_simp->isTrue());
     std::cout << "  ✓ PASSED" << std::endl;
     
     // Test 7: Complex store chain equality
@@ -337,7 +336,7 @@ void test_array_equality(ParserPtr& parser) {
     std::cout << "  Output: " << dumpSMTLIB2(eq7) << std::endl;
     std::cout << "  Expected: true (canonical form should be same)" << std::endl;
     auto eq7_simp = parser->arithNormalize(eq7);
-    assert(eq7_simp->isTrue());
+    VERIFY(eq7_simp->isTrue());
     std::cout << "  ✓ PASSED" << std::endl;
 }
 

--- a/test/theory/test_array_theory.cpp
+++ b/test/theory/test_array_theory.cpp
@@ -5,7 +5,7 @@
 #include "somtparser/ir/number.h"
 #include "somtparser/ir/value.h"
 #include "somtparser/model/model.h"
-#include <cassert>
+#include "test_helpers.h"
 
 // Test array creation and basic operations
 void test_array_creation(SOMTParser::ParserPtr& parser) {
@@ -13,8 +13,8 @@ void test_array_creation(SOMTParser::ParserPtr& parser) {
     
     std::shared_ptr<SOMTParser::Sort> int_sort = SOMTParser::SortManager::INT_SORT;
     std::shared_ptr<SOMTParser::DAGNode> array = parser->mkArray("testArray", int_sort, int_sort);
-    assert(array);
-    assert(parser->toString(array).find("testArray") != std::string::npos);
+    VERIFY(array);
+    VERIFY(parser->toString(array).find("testArray") != std::string::npos);
     std::cout << "Created array: " << parser->toString(array) << std::endl;
     std::cout << std::endl;
 }
@@ -34,15 +34,15 @@ void test_array_operations(SOMTParser::ParserPtr& parser) {
     for (const auto& p : cases) {
         std::cout << "Expression: " << p.first << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(p.first);
-        assert(result);
+        VERIFY(result);
         std::string got = parser->toString(result);
         std::cout << "  Result: " << got << std::endl;
         if (!p.second.empty()) {
             auto expected = parser->mkExpr(p.second);
-            assert(expected && result == expected &&
+            VERIFY(expected && result == expected &&
                    "array operation result mismatch");
         } else {
-            assert(got.find("store") != std::string::npos || got.find("select") != std::string::npos || got.find("const") != std::string::npos);
+            VERIFY(got.find("store") != std::string::npos || got.find("select") != std::string::npos || got.find("const") != std::string::npos);
         }
         std::cout << std::endl;
     }
@@ -61,18 +61,18 @@ void test_array_model_select_evaluation(SOMTParser::ParserPtr& p) {
     m->setArrayStore("A", "1", v42);
 
     auto sel = p->mkExpr("(select A 1)");
-    assert(sel && !sel->isErr());
+    VERIFY(sel && !sel->isErr());
     auto ev = p->evaluate(sel, m);
-    assert(ev && !ev->isErr());
-    assert(ev->isCInt());
-    assert(p->toInt(ev) == SOMTParser::Integer(42));
+    VERIFY(ev && !ev->isErr());
+    VERIFY(ev->isCInt());
+    VERIFY(p->toInt(ev) == SOMTParser::Integer(42));
 
     auto sel2 = p->mkExpr("(select A 2)");
-    assert(sel2 && !sel2->isErr());
+    VERIFY(sel2 && !sel2->isErr());
     auto ev2 = p->evaluate(sel2, m);
-    assert(ev2 && !ev2->isErr());
-    assert(ev2->isCInt());
-    assert(p->toInt(ev2) == SOMTParser::Integer(0));
+    VERIFY(ev2 && !ev2->isErr());
+    VERIFY(ev2->isCInt());
+    VERIFY(p->toInt(ev2) == SOMTParser::Integer(0));
 }
 
 void test_value_array_operators_ir() {
@@ -82,13 +82,13 @@ void test_value_array_operators_ir() {
 
     SOMTParser::Value stored =
         arr.store("key1", SOMTParser::Value(SOMTParser::Number(SOMTParser::Integer(42))));
-    assert(stored.getType() == SOMTParser::ARRAY);
+    VERIFY(stored.getType() == SOMTParser::ARRAY);
 
     SOMTParser::Value selected = stored.select("key1");
-    assert(selected.toNumber() == SOMTParser::Number(SOMTParser::Integer(42)));
+    VERIFY(selected.toNumber() == SOMTParser::Number(SOMTParser::Integer(42)));
 
     SOMTParser::Value def_val = stored.select("key2");
-    assert(def_val.getNumberValue() ==
+    VERIFY(def_val.getNumberValue() ==
            SOMTParser::Number(SOMTParser::Integer(99)));
 }
 

--- a/test/theory/test_bitvector.cpp
+++ b/test/theory/test_bitvector.cpp
@@ -5,17 +5,17 @@
 #include "somtparser/frontend/parser.h"
 #include "somtparser/ir/number.h"
 #include "somtparser/ir/value.h"
-#include <cassert>
+#include "test_helpers.h"
 
 // Test bitvector constants
 void test_bv_const_value_and_utils_nat(SOMTParser::ParserPtr& parser) {
     std::cout << "=== BV (_ bv n w) getValue + BitVectorUtils (not getNumberValue) ===" << std::endl;
     auto n = parser->mkExpr("(_ bv42 8)");
-    assert(n && n->isCBV());
+    VERIFY(n && n->isCBV());
     auto v = n->getValue();
-    assert(v && v->getType() == SOMTParser::BV);
-    assert(v->getBvWidth() == 8);
-    assert(SOMTParser::BitVectorUtils::bvToNat(n->toString()) == SOMTParser::Integer(42));
+    VERIFY(v && v->getType() == SOMTParser::BV);
+    VERIFY(v->getBvWidth() == 8);
+    VERIFY(SOMTParser::BitVectorUtils::bvToNat(n->toString()) == SOMTParser::Integer(42));
 }
 
 void test_bitvector_constants(SOMTParser::ParserPtr& parser) {
@@ -30,7 +30,7 @@ void test_bitvector_constants(SOMTParser::ParserPtr& parser) {
     for (const auto& expr : expressions) {
         std::cout << "Expression: " << expr << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(expr);
-        assert(result && !result->isErr());
+        VERIFY(result && !result->isErr());
         std::cout << "  Result: " << parser->toString(result) << std::endl;
         std::cout << std::endl;
     }
@@ -52,7 +52,7 @@ void test_bv_logical_operations(SOMTParser::ParserPtr& parser) {
     for (const auto& expr : expressions) {
         std::cout << "Expression: " << expr << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(expr);
-        assert(result && !result->isErr());
+        VERIFY(result && !result->isErr());
         std::cout << "  Result: " << parser->toString(result) << std::endl;
         std::cout << std::endl;
     }
@@ -76,7 +76,7 @@ void test_bv_arithmetic_operations(SOMTParser::ParserPtr& parser) {
     for (const auto& expr : expressions) {
         std::cout << "Expression: " << expr << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(expr);
-        assert(result && !result->isErr());
+        VERIFY(result && !result->isErr());
         std::cout << "  Result: " << parser->toString(result) << std::endl;
         std::cout << std::endl;
     }
@@ -99,7 +99,7 @@ void test_bv_comparison_operations(SOMTParser::ParserPtr& parser) {
     for (const auto& expr : expressions) {
         std::cout << "Expression: " << expr << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(expr);
-        assert(result && (result->isTrue() || result->isFalse()));
+        VERIFY(result && (result->isTrue() || result->isFalse()));
         std::cout << "  Result: " << parser->toString(result) << std::endl;
         std::cout << std::endl;
     }
@@ -115,17 +115,17 @@ void test_value_bv_operators_ir() {
     b.setBvWidth(4);
 
     SOMTParser::Value r_and = a.andOp(b);
-    assert(r_and.getType() == SOMTParser::BV);
-    assert(r_and.toString() == "0");
+    VERIFY(r_and.getType() == SOMTParser::BV);
+    VERIFY(r_and.toString() == "0");
 
     SOMTParser::Value r_or = a.orOp(b);
-    assert(r_or.toString() == "15");
+    VERIFY(r_or.toString() == "15");
 
     SOMTParser::Value r_xor = a.xorOp(b);
-    assert(r_xor.toString() == "15");
+    VERIFY(r_xor.toString() == "15");
 
     SOMTParser::Value r_shl = a.shift_left(SOMTParser::Number(SOMTParser::Integer(1)));
-    assert(r_shl.toString() == "20");
+    VERIFY(r_shl.toString() == "20");
 }
 
 // ─── Issue #3: BV arithmetic correctness (constant-folding path) ─────────────
@@ -139,38 +139,38 @@ void test_bv_arithmetic_correctness(SOMTParser::ParserPtr& parser) {
     // bvadd: 3 + 5 = 8  (#b0011 + #b0101 = #b1000)
     {
         auto r = parser->mkExpr("(bvadd #b0011 #b0101)");
-        assert(r && r->isCBV());
-        assert(BitVectorUtils::bvToNat(r->toString()) == Integer(8));
+        VERIFY(r && r->isCBV());
+        VERIFY(BitVectorUtils::bvToNat(r->toString()) == Integer(8));
     }
     // bvsub: 10 - 3 = 7  (#b1010 - #b0011 = #b0111)
     {
         auto r = parser->mkExpr("(bvsub #b1010 #b0011)");
-        assert(r && r->isCBV());
-        assert(BitVectorUtils::bvToNat(r->toString()) == Integer(7));
+        VERIFY(r && r->isCBV());
+        VERIFY(BitVectorUtils::bvToNat(r->toString()) == Integer(7));
     }
     // bvmul: 3 * 5 = 15  (#b0011 * #b0101 = #b1111)
     {
         auto r = parser->mkExpr("(bvmul #b0011 #b0101)");
-        assert(r && r->isCBV());
-        assert(BitVectorUtils::bvToNat(r->toString()) == Integer(15));
+        VERIFY(r && r->isCBV());
+        VERIFY(BitVectorUtils::bvToNat(r->toString()) == Integer(15));
     }
     // bvudiv: 10 / 2 = 5  (#b1010 / #b0010 = #b0101)
     {
         auto r = parser->mkExpr("(bvudiv #b1010 #b0010)");
-        assert(r && r->isCBV());
-        assert(BitVectorUtils::bvToNat(r->toString()) == Integer(5));
+        VERIFY(r && r->isCBV());
+        VERIFY(BitVectorUtils::bvToNat(r->toString()) == Integer(5));
     }
     // bvurem: 10 % 3 = 1  (#b1010 % #b0011 = #b0001)
     {
         auto r = parser->mkExpr("(bvurem #b1010 #b0011)");
-        assert(r && r->isCBV());
-        assert(BitVectorUtils::bvToNat(r->toString()) == Integer(1));
+        VERIFY(r && r->isCBV());
+        VERIFY(BitVectorUtils::bvToNat(r->toString()) == Integer(1));
     }
     // overflow check: 15 + 1 wraps to 0 in 4-bit  (#b1111 + #b0001 = #b0000)
     {
         auto r = parser->mkExpr("(bvadd #b1111 #b0001)");
-        assert(r && r->isCBV());
-        assert(BitVectorUtils::bvToNat(r->toString()) == Integer(0));
+        VERIFY(r && r->isCBV());
+        VERIFY(BitVectorUtils::bvToNat(r->toString()) == Integer(0));
     }
     std::cout << "  BV arithmetic correctness (fast path): OK\n";
 }
@@ -186,32 +186,32 @@ void test_bv_large_width_gmp_path(SOMTParser::ParserPtr& parser) {
     // bvadd: 100 + 200 = 300
     {
         auto r = parser->mkExpr("(bvadd (_ bv100 128) (_ bv200 128))");
-        assert(r && r->isCBV() && !r->isErr());
-        assert(BitVectorUtils::bvToNat(r->toString()) == Integer(300));
+        VERIFY(r && r->isCBV() && !r->isErr());
+        VERIFY(BitVectorUtils::bvToNat(r->toString()) == Integer(300));
     }
     // bvsub: 500 - 1 = 499
     {
         auto r = parser->mkExpr("(bvsub (_ bv500 128) (_ bv1 128))");
-        assert(r && r->isCBV() && !r->isErr());
-        assert(BitVectorUtils::bvToNat(r->toString()) == Integer(499));
+        VERIFY(r && r->isCBV() && !r->isErr());
+        VERIFY(BitVectorUtils::bvToNat(r->toString()) == Integer(499));
     }
     // bvmul: 1000 * 1000 = 1000000
     {
         auto r = parser->mkExpr("(bvmul (_ bv1000 128) (_ bv1000 128))");
-        assert(r && r->isCBV() && !r->isErr());
-        assert(BitVectorUtils::bvToNat(r->toString()) == Integer(1000000));
+        VERIFY(r && r->isCBV() && !r->isErr());
+        VERIFY(BitVectorUtils::bvToNat(r->toString()) == Integer(1000000));
     }
     // bvudiv: 1000000 / 1000 = 1000
     {
         auto r = parser->mkExpr("(bvudiv (_ bv1000000 128) (_ bv1000 128))");
-        assert(r && r->isCBV() && !r->isErr());
-        assert(BitVectorUtils::bvToNat(r->toString()) == Integer(1000));
+        VERIFY(r && r->isCBV() && !r->isErr());
+        VERIFY(BitVectorUtils::bvToNat(r->toString()) == Integer(1000));
     }
     // bvurem: 1000007 % 1000 = 7
     {
         auto r = parser->mkExpr("(bvurem (_ bv1000007 128) (_ bv1000 128))");
-        assert(r && r->isCBV() && !r->isErr());
-        assert(BitVectorUtils::bvToNat(r->toString()) == Integer(7));
+        VERIFY(r && r->isCBV() && !r->isErr());
+        VERIFY(BitVectorUtils::bvToNat(r->toString()) == Integer(7));
     }
     std::cout << "  Large BV GMP path: OK\n";
 }

--- a/test/theory/test_boolean_logic.cpp
+++ b/test/theory/test_boolean_logic.cpp
@@ -2,20 +2,20 @@
 #include <string>
 #include <vector>
 #include "somtparser/frontend/parser.h"
-#include <cassert>
+#include "test_helpers.h"
 
 // Test basic boolean constants
 void test_boolean_constants(SOMTParser::ParserPtr& parser) {
     std::cout << "=== Testing Boolean Constants ===" << std::endl;
     auto t = parser->mkExpr("true");
-    assert(t && t->isTrue() && !t->isFalse());
+    VERIFY(t && t->isTrue() && !t->isFalse());
     std::cout << "Expression: true" << std::endl;
     std::cout << "  Result: " << parser->toString(t) << std::endl;
     std::cout << "  isTrue: yes" << std::endl;
     std::cout << "  isFalse: no" << std::endl << std::endl;
 
     auto f = parser->mkExpr("false");
-    assert(f && f->isFalse() && !f->isTrue());
+    VERIFY(f && f->isFalse() && !f->isTrue());
     std::cout << "Expression: false" << std::endl;
     std::cout << "  Result: " << parser->toString(f) << std::endl;
     std::cout << "  isTrue: no" << std::endl;
@@ -46,8 +46,8 @@ void test_logical_operations(SOMTParser::ParserPtr& parser) {
     for (const auto& p : cases) {
         std::cout << "Expression: " << p.first << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(p.first);
-        assert(result);
-        assert(result->isTrue() == p.second || result->isFalse() == !p.second);
+        VERIFY(result);
+        VERIFY(result->isTrue() == p.second || result->isFalse() == !p.second);
         std::cout << "  Result: " << parser->toString(result) << std::endl;
         std::cout << std::endl;
     }
@@ -68,8 +68,8 @@ void test_complex_expressions(SOMTParser::ParserPtr& parser) {
     for (const auto& p : cases) {
         std::cout << "Expression: " << p.first << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(p.first);
-        assert(result);
-        assert(result->isTrue() == p.second || result->isFalse() == !p.second);
+        VERIFY(result);
+        VERIFY(result->isTrue() == p.second || result->isFalse() == !p.second);
         std::cout << "  Result: " << parser->toString(result) << std::endl;
         std::cout << std::endl;
     }

--- a/test/theory/test_datatype_eval.cpp
+++ b/test/theory/test_datatype_eval.cpp
@@ -3,7 +3,6 @@
 
 #include "somtparser/frontend/parser.h"
 #include "somtparser/ir/dag.h"
-#include <cassert>
 #include "../test_helpers.h"
 
 int main() {

--- a/test/theory/test_floating_point.cpp
+++ b/test/theory/test_floating_point.cpp
@@ -7,7 +7,7 @@
 #include "somtparser/ir/number.h"
 #include "somtparser/ir/sort.h"
 #include "somtparser/ir/value.h"
-#include <cassert>
+#include "test_helpers.h"
 
 using SOMTParser::BitVectorUtils;
 using SOMTParser::fpNodeToFloat32;
@@ -20,53 +20,53 @@ namespace {
 
 void assert_fp32_near(const std::shared_ptr<SOMTParser::DAGNode>& n, float expected,
                       float eps = 1e-3f) {
-    assert(n && !n->isErr() && n->isCFP());
+    VERIFY(n && !n->isErr() && n->isCFP());
     auto v = fpNodeToFloat32(n);
-    assert(v.has_value());
-    assert(std::fabs(*v - expected) < eps);
+    VERIFY(v.has_value());
+    VERIFY(std::fabs(*v - expected) < eps);
 }
 
 void simp_expect_fp32(ParserPtr& p, const char* smt, float expected, float eps = 1e-3f) {
     auto e = p->mkExpr(smt);
-    assert(e && !e->isErr());
+    VERIFY(e && !e->isErr());
     assert_fp32_near(e, expected, eps);
 }
 
 void simp_expect_real_near(ParserPtr& p, const char* smt, double expected, double eps = 1e-6) {
     auto e = p->mkExpr(smt);
-    assert(e && !e->isErr());
-    assert(e->isCReal() || e->isCInt());
+    VERIFY(e && !e->isErr());
+    VERIFY(e->isCReal() || e->isCInt());
     double v;
     if (e->isCInt()) {
         v = static_cast<double>(p->toInt(e).toLong());
     } else {
         v = p->toReal(e).toDouble();
     }
-    assert(std::fabs(v - expected) < eps);
+    VERIFY(std::fabs(v - expected) < eps);
 }
 
 void simp_expect_bool(ParserPtr& p, const char* smt, bool expected) {
     auto e = p->mkExpr(smt);
-    assert(e && !e->isErr());
+    VERIFY(e && !e->isErr());
     if (expected) {
-        assert(e->isTrue());
+        VERIFY(e->isTrue());
     } else {
-        assert(e->isFalse());
+        VERIFY(e->isFalse());
     }
 }
 
 void simp_expect_cbv_nat(ParserPtr& p, const char* smt, const Integer& expected_nat) {
     auto e = p->mkExpr(smt);
-    assert(e && !e->isErr());
-    assert(e->isCBV());
-    assert(BitVectorUtils::bvToNat(e->toString()) == expected_nat);
+    VERIFY(e && !e->isErr());
+    VERIFY(e->isCBV());
+    VERIFY(BitVectorUtils::bvToNat(e->toString()) == expected_nat);
 }
 
 void simp_expect_cbv_int(ParserPtr& p, const char* smt, const Integer& expected_signed) {
     auto e = p->mkExpr(smt);
-    assert(e && !e->isErr());
-    assert(e->isCBV());
-    assert(BitVectorUtils::bvToInt(e->toString()) == expected_signed);
+    VERIFY(e && !e->isErr());
+    VERIFY(e->isCBV());
+    VERIFY(BitVectorUtils::bvToInt(e->toString()) == expected_signed);
 }
 
 // Parse-time constant folding for FP ops (simp)
@@ -133,11 +133,11 @@ void test_value_fp_operators_ir() {
     b.setFpValue("3.0", 8, 24);
 
     Value sum = a.fadd(b);
-    assert(sum.getType() == SOMTParser::FP);
+    VERIFY(sum.getType() == SOMTParser::FP);
     Value diff = a.fsub(b);
-    assert(diff.getType() == SOMTParser::FP);
+    VERIFY(diff.getType() == SOMTParser::FP);
     Value prod = a.fmul(b);
-    assert(prod.getType() == SOMTParser::FP);
+    VERIFY(prod.getType() == SOMTParser::FP);
 }
 
 }  // namespace
@@ -158,7 +158,7 @@ void test_fp_constants(SOMTParser::ParserPtr& parser) {
     for (const auto& expr : expressions) {
         std::cout << "Expression: " << expr << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(expr);
-        assert(result && !result->isErr());
+        VERIFY(result && !result->isErr());
         std::cout << "  Result: " << parser->toString(result) << std::endl;
         std::cout << std::endl;
     }
@@ -183,7 +183,7 @@ void test_fp_arithmetic(SOMTParser::ParserPtr& parser) {
     for (const auto& expr : expressions) {
         std::cout << "Expression: " << expr << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(expr);
-        assert(result && !result->isErr());
+        VERIFY(result && !result->isErr());
         std::cout << "  Result: " << parser->toString(result) << std::endl;
         std::cout << std::endl;
     }
@@ -210,7 +210,7 @@ void test_fp_comparisons(SOMTParser::ParserPtr& parser) {
     for (const auto& expr : expressions) {
         std::cout << "Expression: " << expr << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(expr);
-        assert(result && !result->isErr());
+        VERIFY(result && !result->isErr());
         std::cout << "  Result: " << parser->toString(result) << std::endl;
         std::cout << std::endl;
     }
@@ -220,25 +220,25 @@ void test_fp_comparisons(SOMTParser::ParserPtr& parser) {
 void test_fp_const_get_value_set(SOMTParser::ParserPtr& parser) {
     std::cout << "=== FP const getValue (mkConstFp / to_fp) ===" << std::endl;
     auto n = parser->mkExpr("((_ to_fp 8 24) RNE 1.0)");
-    assert(n && !n->isErr() && n->isCFP());
+    VERIFY(n && !n->isErr() && n->isCFP());
     auto val = n->getValue();
-    assert(val != nullptr);
-    assert(val->getType() == SOMTParser::FP);
+    VERIFY(val != nullptr);
+    VERIFY(val->getType() == SOMTParser::FP);
 }
 
 void test_fp_sort_width_contract(SOMTParser::ParserPtr& parser) {
     std::cout << "=== FP Sort getExponentWidth / getSignificandWidth contract ===" << std::endl;
     auto sm = parser->getSortManager();
     auto custom = sm->createFPSort(11, 53);
-    assert(custom->getExponentWidth() == 11);
-    assert(custom->getSignificandWidth() == 53);
+    VERIFY(custom->getExponentWidth() == 11);
+    VERIFY(custom->getSignificandWidth() == 53);
     auto f32 = SOMTParser::SortManager::getFloat32();
-    assert(f32->getExponentWidth() == 8);
-    assert(f32->getSignificandWidth() == 24);
+    VERIFY(f32->getExponentWidth() == 8);
+    VERIFY(f32->getSignificandWidth() == 24);
     auto n = parser->mkExpr("((_ to_fp 8 24) RNE 1.0)");
-    assert(n && n->getSort() && n->getSort()->isFp());
-    assert(n->getSort()->getExponentWidth() == 8);
-    assert(n->getSort()->getSignificandWidth() == 24);
+    VERIFY(n && n->getSort() && n->getSort()->isFp());
+    VERIFY(n->getSort()->getExponentWidth() == 8);
+    VERIFY(n->getSort()->getSignificandWidth() == 24);
 }
 
 void test_fp_conversions(SOMTParser::ParserPtr& parser) {
@@ -267,7 +267,7 @@ void test_fp_conversions(SOMTParser::ParserPtr& parser) {
     for (const auto& expr : expressions) {
         std::cout << "Expression: " << expr << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(expr);
-        assert(result && !result->isErr());
+        VERIFY(result && !result->isErr());
         std::cout << "  Result: " << parser->toString(result) << std::endl;
         std::cout << std::endl;
     }

--- a/test/theory/test_fp_util_wrappers.cpp
+++ b/test/theory/test_fp_util_wrappers.cpp
@@ -6,7 +6,7 @@
 #include "somtparser/frontend/parser.h"
 #include "somtparser/core/util.h"
 #include "somtparser/ir/value.h"
-#include <cassert>
+#include "test_helpers.h"
 
 int main() {
     using namespace SOMTParser;
@@ -15,74 +15,74 @@ int main() {
 
     {
         auto nanN = parser->mkExpr("(_ NaN 8 24)");
-        assert(nanN && !nanN->isErr());
-        assert(fpNodeIsNaN(nanN));
-        assert(!fpNodeIsInf(nanN));
-        assert(!fpNodeIsZero(nanN));
+        VERIFY(nanN && !nanN->isErr());
+        VERIFY(fpNodeIsNaN(nanN));
+        VERIFY(!fpNodeIsInf(nanN));
+        VERIFY(!fpNodeIsZero(nanN));
     }
 
     {
         auto pinf = parser->mkExpr("(_ +oo 8 24)");
-        assert(pinf && fpNodeIsInf(pinf) && !fpNodeIsNeg(pinf));
+        VERIFY(pinf && fpNodeIsInf(pinf) && !fpNodeIsNeg(pinf));
         auto ninf = parser->mkExpr("(_ -oo 8 24)");
-        assert(ninf && fpNodeIsInf(ninf) && fpNodeIsNeg(ninf));
+        VERIFY(ninf && fpNodeIsInf(ninf) && fpNodeIsNeg(ninf));
     }
 
     {
         auto pz = parser->mkExpr("(_ +zero 8 24)");
-        assert(pz && fpNodeIsZero(pz) && !fpNodeIsNeg(pz));
+        VERIFY(pz && fpNodeIsZero(pz) && !fpNodeIsNeg(pz));
         auto nz = parser->mkExpr("(_ -zero 8 24)");
-        assert(nz && fpNodeIsZero(nz) && fpNodeIsNeg(nz));
+        VERIFY(nz && fpNodeIsZero(nz) && fpNodeIsNeg(nz));
     }
 
     {
         auto one = parser->mkExpr("((_ to_fp 8 24) RNE 1.0)");
-        assert(one && fpNodeIsNormal(one) && !fpNodeIsSubnormal(one));
-        assert(!fpNodeIsNeg(one));
+        VERIFY(one && fpNodeIsNormal(one) && !fpNodeIsSubnormal(one));
+        VERIFY(!fpNodeIsNeg(one));
         auto neg = parser->mkExpr("((_ to_fp 8 24) RNE -2.5)");
-        assert(neg && fpNodeIsNeg(neg));
+        VERIFY(neg && fpNodeIsNeg(neg));
     }
 
     {
         auto sub = parser->mkExpr("(fp #b0 #b00000000 #b00000000000000000000001)");
-        assert(sub && fpNodeIsSubnormal(sub));
-        assert(sub->getValue() != nullptr);
-        assert(sub->getValue()->getType() == ValueType::FP);
+        VERIFY(sub && fpNodeIsSubnormal(sub));
+        VERIFY(sub->getValue() != nullptr);
+        VERIFY(sub->getValue()->getType() == ValueType::FP);
     }
 
     {
         auto rm = parser->mkExpr("RNE");
-        assert(rm);
-        assert(getFPRoundingMode(rm) == FE_TONEAREST);
+        VERIFY(rm);
+        VERIFY(getFPRoundingMode(rm) == FE_TONEAREST);
     }
 
     {
         float x = 1.375f;
         std::string smt = float32ToSMTFP(x);
         auto n = parser->mkExpr(smt);
-        assert(n && !n->isErr());
+        VERIFY(n && !n->isErr());
         auto back = fpNodeToFloat32(n);
-        assert(back.has_value());
-        assert(std::fabs(static_cast<double>(*back - x)) < 1e-6);
+        VERIFY(back.has_value());
+        VERIFY(std::fabs(static_cast<double>(*back - x)) < 1e-6);
     }
 
     {
         double y = -3.125;
         std::string smt = float64ToSMTFP(y);
         auto n = parser->mkExpr(smt);
-        assert(n && !n->isErr());
+        VERIFY(n && !n->isErr());
         auto back = fpNodeToFloat64(n);
-        assert(back.has_value());
-        assert(std::fabs(*back - y) < 1e-12);
+        VERIFY(back.has_value());
+        VERIFY(std::fabs(*back - y) < 1e-12);
     }
 
     {
         ModelPtr model = newModel();
         auto phi = parser->mkExpr("(fp.isNaN (_ NaN 8 24))");
-        assert(phi && !phi->isErr());
+        VERIFY(phi && !phi->isErr());
         auto ev = parser->evaluate(phi, model);
-        assert(ev && ev->isTrue());
-        assert(parser->toString(ev) == "true");
+        VERIFY(ev && ev->isTrue());
+        VERIFY(parser->toString(ev) == "true");
     }
 
     std::cout << "test_fp_util_wrappers: all assertions passed\n";

--- a/test/theory/test_number_risks.cpp
+++ b/test/theory/test_number_risks.cpp
@@ -5,7 +5,7 @@
 #include "somtparser/frontend/parser.h"
 #include "somtparser/core/util.h"
 #include "somtparser/ir/dag.h"
-#include <cassert>
+#include "test_helpers.h"
 
 using namespace SOMTParser;
 
@@ -18,14 +18,14 @@ void test_A1_sort_vs_value_type() {
     std::cout << "[A1] Sort vs Value type confusion... " << std::flush;
     ParserPtr parser = newParser();
     auto node = parser->mkExpr("(/ 10 2)");
-    assert(node != nullptr);
-    assert(node->getSort()->isReal());
-    assert(node->isCReal());
-    assert(!node->isCInt());
+    VERIFY(node != nullptr);
+    VERIFY(node->getSort()->isReal());
+    VERIFY(node->isCReal());
+    VERIFY(!node->isCInt());
     auto val = node->getValue()->getNumberValue();
-    assert(val.isInteger());          // Value type is INT_TYPE, but sort is Real
+    VERIFY(val.isInteger());          // Value type is INT_TYPE, but sort is Real
     // Risk: code that assumes isCReal() => val.isReal() would be wrong
-    assert(!val.isReal());            // INT_TYPE is not REAL_TYPE
+    VERIFY(!val.isReal());            // INT_TYPE is not REAL_TYPE
     std::cout << "PASS (Value=INT_TYPE, Sort=Real)" << std::endl;
 }
 
@@ -34,10 +34,10 @@ void test_A2_intorreal_leak() {
     std::cout << "[A2] IntOrReal sort leakage... " << std::flush;
     ParserPtr parser = newParser();
     auto node = parser->mkExpr("5");
-    assert(node != nullptr);
-    assert(node->isCInt());
-    assert(node->isCReal());          // IntOrReal satisfies BOTH
-    assert(node->getSort()->isIntOrReal());
+    VERIFY(node != nullptr);
+    VERIFY(node->isCInt());
+    VERIFY(node->isCReal());          // IntOrReal satisfies BOTH
+    VERIFY(node->getSort()->isIntOrReal());
     // Risk: if this node enters backend without resolution, solver sees ambiguous sort
     std::cout << "PASS (sort=IntOrReal, isCInt=true, isCReal=true)" << std::endl;
 }
@@ -47,15 +47,15 @@ void test_A3_dual_identity() {
     std::cout << "[A3] Dual identity (/ 10 2)... " << std::flush;
     ParserPtr parser = newParser();
     auto node = parser->mkExpr("(/ 10 2)");
-    assert(node != nullptr);
-    assert(node->getSort()->isReal());
+    VERIFY(node != nullptr);
+    VERIFY(node->getSort()->isReal());
     auto val = node->getValue()->getNumberValue();
-    assert(val.isInteger());
-    assert(!val.isRational());        // den==1, downgraded to INT_TYPE
-    assert(val.asIntegerExact().has_value());
-    assert(val.asIntegerExact()->toString() == "5");
+    VERIFY(val.isInteger());
+    VERIFY(!val.isRational());        // den==1, downgraded to INT_TYPE
+    VERIFY(val.asIntegerExact().has_value());
+    VERIFY(val.asIntegerExact()->toString() == "5");
     // toRationalExact() on INT_TYPE should still work (returns 5/1)
-    assert(val.toRationalExact() == HighPrecisionRational("5/1"));
+    VERIFY(val.toRationalExact() == HighPrecisionRational("5/1"));
     std::cout << "PASS (sort=Real, Value=INT_TYPE 5)" << std::endl;
 }
 
@@ -66,30 +66,30 @@ void test_A4_div_vs_slash_semantics() {
 
     // (div 7 3) -> 2 (floor)
     auto divInt = parser->mkExpr("(div 7 3)");
-    assert(divInt != nullptr);
-    assert(divInt->getSort()->isInt());
-    assert(parser->toString(divInt) == "2");
+    VERIFY(divInt != nullptr);
+    VERIFY(divInt->getSort()->isInt());
+    VERIFY(parser->toString(divInt) == "2");
 
     // (div -7 3) -> -3 (floor towards -inf)
     auto divIntNeg = parser->mkExpr("(div -7 3)");
-    assert(divIntNeg != nullptr);
-    assert(divIntNeg->getSort()->isInt());
-    assert(parser->toInt(divIntNeg) == Integer(-3));
+    VERIFY(divIntNeg != nullptr);
+    VERIFY(divIntNeg->getSort()->isInt());
+    VERIFY(parser->toInt(divIntNeg) == Integer(-3));
 
     // (/ 7 3) -> 7/3 (RATIONAL_TYPE)
     auto divReal = parser->mkExpr("(/ 7 3)");
-    assert(divReal != nullptr);
-    assert(divReal->getSort()->isReal());
+    VERIFY(divReal != nullptr);
+    VERIFY(divReal->getSort()->isReal());
     auto val = divReal->getValue()->getNumberValue();
-    assert(val.isRational());
-    assert(val.toRationalExact() == HighPrecisionRational("7/3"));
+    VERIFY(val.isRational());
+    VERIFY(val.toRationalExact() == HighPrecisionRational("7/3"));
 
     // (/ 6 3) -> sort Real, even though value is integer
     auto divReal2 = parser->mkExpr("(/ 6 3)");
-    assert(divReal2 != nullptr);
-    assert(divReal2->getSort()->isReal());
+    VERIFY(divReal2 != nullptr);
+    VERIFY(divReal2->getSort()->isReal());
     auto val2 = divReal2->getValue()->getNumberValue();
-    assert(val2.isInteger());  // 6/3=2, but it's INT_TYPE under Real sort
+    VERIFY(val2.isInteger());  // 6/3=2, but it's INT_TYPE under Real sort
 
     std::cout << "PASS" << std::endl;
 }
@@ -100,8 +100,8 @@ void test_A5_operator_div_overload() {
     Number a(6);      // INT_TYPE
     Number b(3);      // INT_TYPE
     Number c = a / b; // Currently returns INT_TYPE 2 (via HPRational)
-    assert(c.isInteger());
-    assert(c.getType() == Number::INT_TYPE);
+    VERIFY(c.isInteger());
+    VERIFY(c.getType() == Number::INT_TYPE);
     // Risk: in a "Real division" context, we got INT_TYPE instead of RATIONAL_TYPE
     // This is the current design; the sort of the DAG node determines SMT semantics,
     // not the Number::Type. Documented here as a boundary.
@@ -115,12 +115,12 @@ void test_A5_operator_div_overload() {
 // B6 — TypeChecker::isReal("a/b") 接受有理数字符串
 void test_B6_typechecker_isreal_rational() {
     std::cout << "[B6] TypeChecker::isReal on rational strings... " << std::flush;
-    assert(TypeChecker::isReal("1/2") == true);
-    assert(TypeChecker::isReal("3/4") == true);
-    assert(TypeChecker::isReal("-7/3") == true);
-    assert(TypeChecker::isReal("1/") == false);
-    assert(TypeChecker::isReal("/2") == false);
-    assert(TypeChecker::isReal("1//2") == false);
+    VERIFY(TypeChecker::isReal("1/2") == true);
+    VERIFY(TypeChecker::isReal("3/4") == true);
+    VERIFY(TypeChecker::isReal("-7/3") == true);
+    VERIFY(TypeChecker::isReal("1/") == false);
+    VERIFY(TypeChecker::isReal("/2") == false);
+    VERIFY(TypeChecker::isReal("1//2") == false);
     // Risk: lexer should not accept raw 1/2 as a single token in SMT-LIB input
     // But TypeChecker is used internally after parsing, so this is acceptable
     std::cout << "PASS" << std::endl;
@@ -130,8 +130,8 @@ void test_B6_typechecker_isreal_rational() {
 void test_B7_toString_canonical() {
     std::cout << "[B7] toString() canonical format... " << std::flush;
     Number n("0.5", false);
-    assert(n.toString() == "1/2");
-    assert(n.isRational());
+    VERIFY(n.toString() == "1/2");
+    VERIFY(n.isRational());
     // dumpSMTLIB2 converts a/b -> (/ a b), so toString() should stay as a/b
     std::cout << "PASS" << std::endl;
 }
@@ -141,13 +141,13 @@ void test_B8_name_value_consistency() {
     std::cout << "[B8] DAG name vs Value consistency... " << std::flush;
     ParserPtr parser = newParser();
     auto n1 = parser->mkExpr("0.5");
-    assert(n1 != nullptr);
-    assert(n1->getName() == "1/2");  // canonicalized name
-    assert(n1->getValue()->getNumberValue().toString() == "1/2");
+    VERIFY(n1 != nullptr);
+    VERIFY(n1->getName() == "1/2");  // canonicalized name
+    VERIFY(n1->getValue()->getNumberValue().toString() == "1/2");
     auto n2 = parser->mkExpr("1/2");
-    assert(n2 != nullptr);
-    assert(n2->getName() == "1/2");
-    assert(n2->getValue()->getNumberValue().toString() == "1/2");
+    VERIFY(n2 != nullptr);
+    VERIFY(n2->getName() == "1/2");
+    VERIFY(n2->getValue()->getNumberValue().toString() == "1/2");
     std::cout << "PASS" << std::endl;
 }
 
@@ -157,11 +157,11 @@ void test_B9_hash_cons_identity() {
     ParserPtr parser = newParser();
     auto a = parser->mkExpr("0.5");
     auto b = parser->mkExpr("1/2");
-    assert(a != nullptr);
-    assert(b != nullptr);
+    VERIFY(a != nullptr);
+    VERIFY(b != nullptr);
     // After canonicalization in mkConstReal(string), 0.5 becomes name "1/2"
     // so hash-cons should share them
-    assert(a == b);
+    VERIFY(a == b);
     std::cout << "PASS (0.5 and 1/2 share same node)" << std::endl;
 }
 
@@ -169,14 +169,14 @@ void test_B9_hash_cons_identity() {
 void test_B10_rational_downgrade() {
     std::cout << "[B10] RATIONAL_TYPE den=1 downgrade... " << std::flush;
     Number n1("10/2", false);
-    assert(n1.isInteger());
-    assert(n1.getType() == Number::INT_TYPE);
-    assert(n1.asIntegerExact()->toString() == "5");
+    VERIFY(n1.isInteger());
+    VERIFY(n1.getType() == Number::INT_TYPE);
+    VERIFY(n1.asIntegerExact()->toString() == "5");
 
     Number n2(HighPrecisionRational("10/2"));
-    assert(n2.isInteger());
-    assert(n2.getType() == Number::INT_TYPE);
-    assert(n2.asIntegerExact()->toString() == "5");
+    VERIFY(n2.isInteger());
+    VERIFY(n2.getType() == Number::INT_TYPE);
+    VERIFY(n2.asIntegerExact()->toString() == "5");
     std::cout << "PASS" << std::endl;
 }
 
@@ -184,10 +184,10 @@ void test_B10_rational_downgrade() {
 void test_B11_negative_zero() {
     std::cout << "[B11] Negative zero canonicalization... " << std::flush;
     Number n("-0.0", false);
-    assert(n.isInteger());
-    assert(n.getType() == Number::INT_TYPE);
-    assert(n.toString() == "0");
-    assert(n.asIntegerExact()->toString() == "0");
+    VERIFY(n.isInteger());
+    VERIFY(n.getType() == Number::INT_TYPE);
+    VERIFY(n.toString() == "0");
+    VERIFY(n.asIntegerExact()->toString() == "0");
     std::cout << "PASS" << std::endl;
 }
 
@@ -196,26 +196,26 @@ void test_B12_scientific_notation() {
     std::cout << "[B12] Scientific notation... " << std::flush;
     ParserPtr parser = newParser();
     auto node = parser->mkExpr("1.23e-5");
-    assert(node != nullptr);
-    assert(node->getSort()->isReal());
+    VERIFY(node != nullptr);
+    VERIFY(node->getSort()->isReal());
     // Value should be exact rational 123/10000000
     auto val = node->getValue()->getNumberValue();
-    assert(val.isRational());
-    assert(val.toRationalExact() == HighPrecisionRational("123/10000000"));
+    VERIFY(val.isRational());
+    VERIFY(val.toRationalExact() == HighPrecisionRational("123/10000000"));
     std::cout << "PASS (1.23e-5 -> 123/10000000)" << std::endl;
 }
 
 // B13 — isReal() 边界格式
 void test_B13_isreal_boundaries() {
     std::cout << "[B13] isReal() boundary formats... " << std::flush;
-    assert(TypeChecker::isReal("1.2.3") == false);
-    assert(TypeChecker::isReal("1/2/3") == false);
-    assert(TypeChecker::isReal("") == false);
-    assert(TypeChecker::isReal("-") == false);
-    assert(TypeChecker::isReal("e5") == false);
-    assert(TypeChecker::isReal(".") == false);
-    assert(TypeChecker::isReal("1.") == true);   // valid decimal
-    assert(TypeChecker::isReal(".5") == true);   // valid decimal
+    VERIFY(TypeChecker::isReal("1.2.3") == false);
+    VERIFY(TypeChecker::isReal("1/2/3") == false);
+    VERIFY(TypeChecker::isReal("") == false);
+    VERIFY(TypeChecker::isReal("-") == false);
+    VERIFY(TypeChecker::isReal("e5") == false);
+    VERIFY(TypeChecker::isReal(".") == false);
+    VERIFY(TypeChecker::isReal("1.") == true);   // valid decimal
+    VERIFY(TypeChecker::isReal(".5") == true);   // valid decimal
     std::cout << "PASS" << std::endl;
 }
 
@@ -227,14 +227,14 @@ void test_B13_isreal_boundaries() {
 void test_C14_approximate_to_rational() {
     std::cout << "[C14] approximateToRational() precision loss... " << std::flush;
     Number approx = Number::fromApproxDouble(1.0 / 3.0);
-    assert(approx.isReal());
+    VERIFY(approx.isReal());
     HighPrecisionRational r = approx.approximateToRational();
     // This uses HighPrecisionRational(realValue.toString()) internally
     // The result is approximate, not exact 1/3
-    assert(r != HighPrecisionRational("1/3"));  // Should NOT be exact
+    VERIFY(r != HighPrecisionRational("1/3"));  // Should NOT be exact
     // But should be close
     double diff = std::abs(r.toDouble() - 1.0 / 3.0);
-    assert(diff < 1e-15);
+    VERIFY(diff < 1e-15);
     std::cout << "PASS (documented approximate boundary)" << std::endl;
 }
 
@@ -244,10 +244,10 @@ void test_C15_real_type_in_folding() {
     ParserPtr parser = newParser();
     parser->setEvaluateUseFloating(true);
     auto node = parser->mkExpr("(sin 1)");
-    assert(node != nullptr);
-    assert(node->getSort()->isReal());
+    VERIFY(node != nullptr);
+    VERIFY(node->getSort()->isReal());
     auto val = node->getValue()->getNumberValue();
-    assert(val.isReal());  // REAL_TYPE
+    VERIFY(val.isReal());  // REAL_TYPE
     // toRationalExact() should reject REAL_TYPE
     bool threw = false;
     try {
@@ -255,7 +255,7 @@ void test_C15_real_type_in_folding() {
     } catch (const std::runtime_error&) {
         threw = true;
     }
-    assert(threw);
+    VERIFY(threw);
     std::cout << "PASS (REAL_TYPE rejected by toRationalExact)" << std::endl;
 }
 
@@ -267,7 +267,7 @@ void test_C16_real_type_in_comparison() {
     // sin(pi) is theoretically 0, but MPFR approximation might not be exact
     // The comparison should NOT incorrectly fold to true/false
     auto node = parser->mkExpr("(< (sin pi) 0.001)");
-    assert(node != nullptr);
+    VERIFY(node != nullptr);
     // If it folded, it would be a Bool constant; if not, it's a comparison node
     // We document the current behavior without asserting a specific outcome,
     // because MPFR precision-dependent folding is inherently approximate.
@@ -279,14 +279,14 @@ void test_C17_dump_negative_rational() {
     std::cout << "[C17] dump negative rational... " << std::flush;
     ParserPtr parser = newParser();
     auto node = parser->mkExpr("(- (/ 1 10))");
-    assert(node != nullptr);
+    VERIFY(node != nullptr);
     std::string dumped = dumpSMTLIB2(node);
-    assert(dumped.find("(- (/ 1 10))") != std::string::npos);
+    VERIFY(dumped.find("(- (/ 1 10))") != std::string::npos);
 
     auto neg = parser->mkExpr("(- 0.5)");
-    assert(neg != nullptr);
+    VERIFY(neg != nullptr);
     std::string dumped2 = dumpSMTLIB2(neg);
-    assert(dumped2.find("(- (/ 1 2))") != std::string::npos);
+    VERIFY(dumped2.find("(- (/ 1 2))") != std::string::npos);
     std::cout << "PASS" << std::endl;
 }
 
@@ -294,8 +294,8 @@ void test_C17_dump_negative_rational() {
 void test_C18_unknown_type() {
     std::cout << "[C18] Default Number contract... " << std::flush;
     Number n;
-    assert(n.getType() == Number::INT_TYPE);
-    assert(n == Number(0));
+    VERIFY(n.getType() == Number::INT_TYPE);
+    VERIFY(n == Number(0));
     std::cout << "PASS (default Number is integer zero)" << std::endl;
 }
 
@@ -317,7 +317,7 @@ void test_C20_toReal_precision() {
     // toReal() is approximate, not mathematically exact
     Real expected(0.1, 128);
     Real diff = (r - expected).abs();
-    assert(diff.toDouble() > 0.0 && diff.toDouble() < 1e-15);
+    VERIFY(diff.toDouble() > 0.0 && diff.toDouble() < 1e-15);
     std::cout << "PASS (toReal is approximate, documented)" << std::endl;
 }
 
@@ -326,15 +326,15 @@ void test_C21_dump_nested_negative() {
     std::cout << "[C21] dump nested negative rational... " << std::flush;
     ParserPtr parser = newParser();
     auto node = parser->mkExpr("(- (/ 7 3))");
-    assert(node != nullptr);
+    VERIFY(node != nullptr);
     std::string dumped = dumpSMTLIB2(node);
-    assert(dumped == "(- (/ 7 3))");
+    VERIFY(dumped == "(- (/ 7 3))");
 
     // Also test negative decimal
     auto negDec = parser->mkExpr("(- 0.5)");
-    assert(negDec != nullptr);
+    VERIFY(negDec != nullptr);
     std::string dumped2 = dumpSMTLIB2(negDec);
-    assert(dumped2 == "(- (/ 1 2))");
+    VERIFY(dumped2 == "(- (/ 1 2))");
     std::cout << "PASS" << std::endl;
 }
 
@@ -348,11 +348,11 @@ void test_mixed_int_real_folding() {
     ParserPtr parser = newParser();
     // (+ 1 2.5) -> all promoted to Real
     auto node = parser->mkExpr("(+ 1 2.5)");
-    assert(node != nullptr);
-    assert(node->getSort()->isReal());
+    VERIFY(node != nullptr);
+    VERIFY(node->getSort()->isReal());
     auto val = node->getValue()->getNumberValue();
-    assert(val.isRational());
-    assert(val.toRationalExact() == HighPrecisionRational("7/2"));
+    VERIFY(val.isRational());
+    VERIFY(val.toRationalExact() == HighPrecisionRational("7/2"));
     std::cout << "PASS" << std::endl;
 }
 
@@ -361,8 +361,8 @@ void test_isRealParam_intorreal() {
     std::cout << "[EXTRA] isRealParam accepts IntOrReal... " << std::flush;
     ParserPtr parser = newParser();
     auto node = parser->mkExpr("5");  // IntOrReal sort
-    assert(node != nullptr);
-    assert(node->getSort()->isIntOrReal());
+    VERIFY(node != nullptr);
+    VERIFY(node->getSort()->isIntOrReal());
     std::cout << "PASS" << std::endl;
 }
 

--- a/test/theory/test_number_semantics.cpp
+++ b/test/theory/test_number_semantics.cpp
@@ -3,7 +3,7 @@
 #include "somtparser/ir/number.h"
 #include "somtparser/frontend/parser.h"
 #include "somtparser/core/util.h"
-#include <cassert>
+#include "test_helpers.h"
 
 using namespace SOMTParser;
 
@@ -13,9 +13,9 @@ void test_canonical_equality() {
     // Number("0.5") and Number("1/2") should both normalize to same rational
     Number n1("0.5", false);
     Number n2(std::string("1/2"));
-    assert(n1.isRational());
-    assert(n2.isRational());
-    assert(n1.toRationalExact() == n2.toRationalExact());
+    VERIFY(n1.isRational());
+    VERIFY(n2.isRational());
+    VERIFY(n1.toRationalExact() == n2.toRationalExact());
     std::cout << "  0.5 == 1/2 rational: OK" << std::endl;
 }
 
@@ -26,8 +26,8 @@ void test_exact_decimal_arithmetic() {
     Number b("0.2", false);
     Number c("0.3", false);
     Number sum = a + b;
-    assert(sum.isRational());
-    assert(sum.toRationalExact() == c.toRationalExact());
+    VERIFY(sum.isRational());
+    VERIFY(sum.toRationalExact() == c.toRationalExact());
     std::cout << "  0.1 + 0.2 == 0.3 exact: OK" << std::endl;
 }
 
@@ -36,11 +36,11 @@ void test_real_division_rational() {
     std::cout << "=== Real Division -> Rational ===" << std::endl;
     ParserPtr parser = newParser();
     auto node = parser->mkExpr("(/ 7 3)");
-    assert(node != nullptr);
-    assert(node->isCReal());
+    VERIFY(node != nullptr);
+    VERIFY(node->isCReal());
     std::string s = parser->toString(node);
     std::cout << "  (/ 7 3) -> " << s << std::endl;
-    assert(node->getValue()->getNumberValue().toRationalExact() ==
+    VERIFY(node->getValue()->getNumberValue().toRationalExact() ==
            HighPrecisionRational("7/3"));
 }
 
@@ -49,11 +49,11 @@ void test_int_division_floor() {
     std::cout << "=== Int Division (floor) ===" << std::endl;
     ParserPtr parser = newParser();
     auto node = parser->mkExpr("(div 7 3)");
-    assert(node != nullptr);
-    assert(node->isCInt());
+    VERIFY(node != nullptr);
+    VERIFY(node->isCInt());
     std::string s = parser->toString(node);
     std::cout << "  (div 7 3) -> " << s << std::endl;
-    assert(s == "2");
+    VERIFY(s == "2");
 }
 
 // 5. (mod 7 3) -> 1
@@ -61,11 +61,11 @@ void test_int_modulo() {
     std::cout << "=== Int Modulo ===" << std::endl;
     ParserPtr parser = newParser();
     auto node = parser->mkExpr("(mod 7 3)");
-    assert(node != nullptr);
-    assert(node->isCInt());
+    VERIFY(node != nullptr);
+    VERIFY(node->isCInt());
     std::string s = parser->toString(node);
     std::cout << "  (mod 7 3) -> " << s << std::endl;
-    assert(s == "1");
+    VERIFY(s == "1");
 }
 
 // 6. Int sort cannot accept 1/2 (type error)
@@ -76,8 +76,8 @@ void test_int_sort_rejects_fraction() {
     // expressible as an Int constant. The parser handles (div 1 2) as Int division.
     // We verify that a RATIONAL_TYPE Number cannot be used as Int sort.
     Number r(std::string("1/2"));
-    assert(r.isRational());
-    assert(!r.asIntegerExact().has_value());
+    VERIFY(r.isRational());
+    VERIFY(!r.asIntegerExact().has_value());
     std::cout << "  1/2 not exact integer: OK" << std::endl;
 }
 
@@ -86,9 +86,9 @@ void test_real_sort_accepts_integer() {
     std::cout << "=== Real Sort Accepts Integer ===" << std::endl;
     ParserPtr parser = newParser();
     auto node = parser->mkExpr("5");
-    assert(node != nullptr);
+    VERIFY(node != nullptr);
     // "5" parsed as real context should still work
-    assert(node->isCReal() || node->isCInt());
+    VERIFY(node->isCReal() || node->isCInt());
     std::cout << "  Real sort accepts 5: OK" << std::endl;
 }
 
@@ -96,14 +96,14 @@ void test_real_sort_accepts_integer() {
 void test_toRationalExact_rejects_real() {
     std::cout << "=== toRationalExact Rejects REAL_TYPE ===" << std::endl;
     Number approx = Number::fromApproxDouble(0.1);
-    assert(approx.isReal());
+    VERIFY(approx.isReal());
     bool threw = false;
     try {
         approx.toRationalExact();
     } catch (const std::runtime_error&) {
         threw = true;
     }
-    assert(threw);
+    VERIFY(threw);
     std::cout << "  toRationalExact(REAL_TYPE) throws: OK" << std::endl;
 }
 
@@ -111,9 +111,9 @@ void test_toRationalExact_rejects_real() {
 void test_asIntegerExact_rejects_non_integer() {
     std::cout << "=== asIntegerExact Rejects Non-Integer ===" << std::endl;
     Number r(std::string("7/3"));
-    assert(r.isRational());
+    VERIFY(r.isRational());
     auto opt = r.asIntegerExact();
-    assert(!opt.has_value());
+    VERIFY(!opt.has_value());
     std::cout << "  asIntegerExact(7/3) returns nullopt: OK" << std::endl;
 }
 
@@ -124,7 +124,7 @@ void test_dump_real_fraction() {
     auto node = parser->mkExpr("(/ 1 10)");
     std::string s = dumpSMTLIB2(node);
     std::cout << "  dump (/ 1 10) -> " << s << std::endl;
-    assert(s == "(/ 1 10)");
+    VERIFY(s == "(/ 1 10)");
 }
 
 // 11. dump IntOrReal 1/10 does not output raw 1/10
@@ -134,9 +134,9 @@ void test_dump_real_fraction() {
 void test_negative_zero_canonical() {
     std::cout << "=== Negative Zero Canonicalization ===" << std::endl;
     Number n1("-0.0", false);
-    assert(n1.isInteger());
-    assert(n1.asIntegerExact().has_value());
-    assert(n1.asIntegerExact().value().toString() == "0");
+    VERIFY(n1.isInteger());
+    VERIFY(n1.asIntegerExact().has_value());
+    VERIFY(n1.asIntegerExact().value().toString() == "0");
     std::cout << "  -0.0 -> INT_TYPE 0: OK" << std::endl;
 }
 
@@ -144,9 +144,9 @@ void test_negative_zero_canonical() {
 void test_rational_integer_canonical() {
     std::cout << "=== Rational Integer Canonicalization ===" << std::endl;
     Number n(std::string("10/2"));
-    assert(n.isInteger());
-    assert(n.asIntegerExact().has_value());
-    assert(n.asIntegerExact().value().toString() == "5");
+    VERIFY(n.isInteger());
+    VERIFY(n.asIntegerExact().has_value());
+    VERIFY(n.asIntegerExact().value().toString() == "5");
     std::cout << "  10/2 -> INT_TYPE 5: OK" << std::endl;
 }
 
@@ -154,8 +154,8 @@ void test_rational_integer_canonical() {
 void test_parsed_literals_exact() {
     std::cout << "=== Parsed Literals Are Exact ===" << std::endl;
     Number n("3.14159", false);
-    assert(n.isRational());
-    assert(n.getType() == Number::RATIONAL_TYPE);
+    VERIFY(n.isRational());
+    VERIFY(n.getType() == Number::RATIONAL_TYPE);
     std::cout << "  3.14159 parsed as RATIONAL_TYPE: OK" << std::endl;
 }
 
@@ -183,9 +183,9 @@ void test_real_type_comparison_exact() {
 void test_floorToInteger() {
     std::cout << "=== floorToInteger Semantics ===" << std::endl;
     Number pos(std::string("7/3"));
-    assert(pos.floorToInteger().toString() == "2");
+    VERIFY(pos.floorToInteger().toString() == "2");
     Number neg(std::string("-7/3"));
-    assert(neg.floorToInteger().toString() == "-3");
+    VERIFY(neg.floorToInteger().toString() == "-3");
     std::cout << "  floorToInteger(7/3)=2, floorToInteger(-7/3)=-3: OK" << std::endl;
 }
 
@@ -196,10 +196,10 @@ void test_int_div_floor_negative() {
     // SMT-LIB div is floor towards -inf
     // (div -7 3) should be -3, not -2
     auto node = parser->mkExpr("(div -7 3)");
-    assert(node != nullptr);
+    VERIFY(node != nullptr);
     std::string s = parser->toString(node);
     std::cout << "  (div -7 3) -> " << s << std::endl;
-    assert(s == "(- 3)");
+    VERIFY(s == "(- 3)");
 }
 
 int main() {

--- a/test/theory/test_quantifiers.cpp
+++ b/test/theory/test_quantifiers.cpp
@@ -2,7 +2,7 @@
 #include <string>
 #include <vector>
 #include "somtparser/frontend/parser.h"
-#include <cassert>
+#include "test_helpers.h"
 
 // Test basic quantifier operations (forall and exists)
 void test_basic_quantifiers(SOMTParser::ParserPtr& parser) {
@@ -19,7 +19,7 @@ void test_basic_quantifiers(SOMTParser::ParserPtr& parser) {
     for (const auto& expr : expressions) {
         std::cout << "Expression: " << expr << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(expr);
-        assert(result && !result->isErr());
+        VERIFY(result && !result->isErr());
         std::cout << "  Result: " << parser->toString(result) << std::endl;
         std::cout << std::endl;
     }
@@ -39,7 +39,7 @@ void test_nested_quantifiers(SOMTParser::ParserPtr& parser) {
     for (const auto& expr : expressions) {
         std::cout << "Expression: " << expr << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(expr);
-        assert(result && !result->isErr());
+        VERIFY(result && !result->isErr());
         std::cout << "  Result: " << parser->toString(result) << std::endl;
         std::cout << std::endl;
     }
@@ -66,7 +66,7 @@ void test_quantifiers_with_arrays(SOMTParser::ParserPtr& parser) {
         for (const auto& expr : expressions) {
             std::cout << "Expression: " << expr << std::endl;
             std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(expr);
-            assert(result && !result->isErr());
+            VERIFY(result && !result->isErr());
             std::cout << "  Result: " << parser->toString(result) << std::endl;
             std::cout << std::endl;
         }
@@ -95,11 +95,11 @@ void test_manual_quantifier_creation(SOMTParser::ParserPtr& parser) {
         std::vector<std::shared_ptr<SOMTParser::DAGNode>> forall_params = {x_var, y_var, x_gt_y};
         std::shared_ptr<SOMTParser::DAGNode> forall_formula = parser->mkForall(forall_params);
         
-        assert(forall_formula && parser->toString(forall_formula).find("forall") != std::string::npos);
+        VERIFY(forall_formula && parser->toString(forall_formula).find("forall") != std::string::npos);
         std::cout << "Manually created forall formula: " << parser->toString(forall_formula) << std::endl;
         std::vector<std::shared_ptr<SOMTParser::DAGNode>> exists_params = {x_var, y_var, x_gt_y};
         std::shared_ptr<SOMTParser::DAGNode> exists_formula = parser->mkExists(exists_params);
-        assert(exists_formula && parser->toString(exists_formula).find("exists") != std::string::npos);
+        VERIFY(exists_formula && parser->toString(exists_formula).find("exists") != std::string::npos);
         std::cout << "Manually created exists formula: " << parser->toString(exists_formula) << std::endl;
     } catch (const std::exception& e) {
         std::cout << "Exception: " << e.what() << std::endl;
@@ -151,7 +151,7 @@ void test_practical_quantifier_examples(SOMTParser::ParserPtr& parser) {
         for (const auto& expr : expressions) {
             std::cout << "Expression: " << expr << std::endl;
             std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(expr);
-            assert(result && !result->isErr());
+            VERIFY(result && !result->isErr());
             std::cout << "  Result: " << parser->toString(result) << std::endl;
             std::cout << std::endl;
         }

--- a/test/theory/test_rational.cpp
+++ b/test/theory/test_rational.cpp
@@ -3,7 +3,7 @@
 #include "somtparser/ir/number.h"
 #include "somtparser/frontend/parser.h"
 #include "somtparser/core/util.h"
-#include <cassert>
+#include "test_helpers.h"
 
 using namespace SOMTParser;
 
@@ -12,32 +12,32 @@ void test_high_precision_rational_basic() {
 
     // Decimal parsing
     Rational r1("59.01938237");
-    assert(r1.toString() == "5901938237/100000000");
+    VERIFY(r1.toString() == "5901938237/100000000");
     std::cout << "  59.01938237 -> " << r1.toString() << std::endl;
 
     Rational r2("0.5");
-    assert(r2.toString() == "1/2");
+    VERIFY(r2.toString() == "1/2");
     std::cout << "  0.5 -> " << r2.toString() << std::endl;
 
     Rational r3("-0.125");
-    assert(r3.toString() == "-1/8");
+    VERIFY(r3.toString() == "-1/8");
     std::cout << "  -0.125 -> " << r3.toString() << std::endl;
 
     Rational r4("42");
-    assert(r4.toString() == "42");
+    VERIFY(r4.toString() == "42");
     std::cout << "  42 -> " << r4.toString() << std::endl;
 
     Rational r5("3.0");
-    assert(r5.toString() == "3");
+    VERIFY(r5.toString() == "3");
     std::cout << "  3.0 -> " << r5.toString() << std::endl;
 
     // a/b format parsing
     Rational r6("7/3");
-    assert(r6.toString() == "7/3");
+    VERIFY(r6.toString() == "7/3");
     std::cout << "  7/3 -> " << r6.toString() << std::endl;
 
     Rational r7("-22/7");
-    assert(r7.toString() == "-22/7");
+    VERIFY(r7.toString() == "-22/7");
     std::cout << "  -22/7 -> " << r7.toString() << std::endl;
 
     std::cout << "  Basic parsing OK" << std::endl;
@@ -48,17 +48,17 @@ void test_high_precision_rational_arithmetic() {
 
     Rational a("1/2");
     Rational b("1/4");
-    assert((a + b).toString() == "3/4");
-    assert((a - b).toString() == "1/4");
-    assert((a * b).toString() == "1/8");
-    assert((a / b).toString() == "2");
+    VERIFY((a + b).toString() == "3/4");
+    VERIFY((a - b).toString() == "1/4");
+    VERIFY((a * b).toString() == "1/8");
+    VERIFY((a / b).toString() == "2");
 
     Rational c("7/3");
     Rational d("2/5");
-    assert((c + d).toString() == "41/15");
-    assert((c - d).toString() == "29/15");
-    assert((c * d).toString() == "14/15");
-    assert((c / d).toString() == "35/6");
+    VERIFY((c + d).toString() == "41/15");
+    VERIFY((c - d).toString() == "29/15");
+    VERIFY((c * d).toString() == "14/15");
+    VERIFY((c / d).toString() == "35/6");
 
     std::cout << "  Arithmetic OK" << std::endl;
 }
@@ -67,40 +67,40 @@ void test_number_rational_type() {
     std::cout << "=== Number RATIONAL_TYPE ===" << std::endl;
 
     Number n1("0.5", false);
-    assert(n1.isRational());
-    assert(n1.isReal());
-    assert(n1.toString() == "1/2");
+    VERIFY(n1.isRational());
+    VERIFY(n1.isReal());
+    VERIFY(n1.toString() == "1/2");
     std::cout << "  Number(0.5) type=" << n1.getType() << " str=" << n1.toString() << std::endl;
 
     Number n2("42", false);
-    assert(n2.isInteger());
-    assert(n2.getType() == Number::INT_TYPE);
+    VERIFY(n2.isInteger());
+    VERIFY(n2.getType() == Number::INT_TYPE);
     std::cout << "  Number(42) type=" << n2.getType() << " str=" << n2.toString() << std::endl;
 
     Number n3("3.14159", false);
-    assert(n3.isRational());
+    VERIFY(n3.isRational());
     std::cout << "  Number(3.14159) str=" << n3.toString() << std::endl;
 
     // Integer division that is not exact -> rational
     Number seven(SOMTParser::Integer(7));
     Number three(SOMTParser::Integer(3));
     Number q = seven / three;
-    assert(q.isRational());
-    assert(q.toString() == "7/3");
+    VERIFY(q.isRational());
+    VERIFY(q.toString() == "7/3");
     std::cout << "  7/3 = " << q.toString() << std::endl;
 
     // Exact integer division still integer
     Number six(SOMTParser::Integer(6));
     Number two(SOMTParser::Integer(2));
     Number exact = six / two;
-    assert(exact.isInteger());
-    assert(exact.toString() == "3");
+    VERIFY(exact.isInteger());
+    VERIFY(exact.toString() == "3");
     std::cout << "  6/2 = " << exact.toString() << std::endl;
 
     // toReal conversion
     Number rat(std::string("1/2"));
     Real r = rat.toReal();
-    assert(r.toDouble() == 0.5);
+    VERIFY(r.toDouble() == 0.5);
     std::cout << "  toReal(1/2) = " << r.toDouble() << std::endl;
 
     std::cout << "  Number rational type OK" << std::endl;
@@ -113,30 +113,30 @@ void test_number_mixed_arithmetic() {
     Number r(std::string("1/2"));
 
     Number sum = i + r;
-    assert(sum.isRational());
-    assert(sum.toString() == "11/2");
+    VERIFY(sum.isRational());
+    VERIFY(sum.toString() == "11/2");
     std::cout << "  5 + 1/2 = " << sum.toString() << std::endl;
 
     Number prod = i * r;
-    assert(prod.isRational());
-    assert(prod.toString() == "5/2");
+    VERIFY(prod.isRational());
+    VERIFY(prod.toString() == "5/2");
     std::cout << "  5 * 1/2 = " << prod.toString() << std::endl;
 
     Number diff = i - r;
-    assert(diff.isRational());
-    assert(diff.toString() == "9/2");
+    VERIFY(diff.isRational());
+    VERIFY(diff.toString() == "9/2");
     std::cout << "  5 - 1/2 = " << diff.toString() << std::endl;
 
     Number quot = i / r;
-    assert(quot.isInteger());
-    assert(quot.toString() == "10");
+    VERIFY(quot.isInteger());
+    VERIFY(quot.toString() == "10");
     std::cout << "  5 / 1/2 = " << quot.toString() << std::endl;
 
     // Rational + Rational
     Number a(std::string("1/3"));
     Number b(std::string("1/6"));
     Number s = a + b;
-    assert(s.toString() == "1/2");
+    VERIFY(s.toString() == "1/2");
     std::cout << "  1/3 + 1/6 = " << s.toString() << std::endl;
 
     std::cout << "  Mixed arithmetic OK" << std::endl;
@@ -149,53 +149,53 @@ void test_parser_constant_folding() {
 
     // SMT-LIB rational syntax: (/ 1 10) should fold to exact rational
     auto node1 = parser->mkExpr("(/ 1 10)");
-    assert(node1 != nullptr);
-    assert(node1->isCReal());
+    VERIFY(node1 != nullptr);
+    VERIFY(node1->isCReal());
     std::string s1 = parser->toString(node1);
     std::cout << "  (/ 1 10) -> " << s1 << std::endl;
-    assert(node1->getValue()->getNumberValue().toRationalExact() ==
+    VERIFY(node1->getValue()->getNumberValue().toRationalExact() ==
            HighPrecisionRational("1/10"));
 
     // (/ 7 3)
     auto node2 = parser->mkExpr("(/ 7 3)");
-    assert(node2 != nullptr);
-    assert(node2->isCReal());
+    VERIFY(node2 != nullptr);
+    VERIFY(node2->isCReal());
     std::string s2 = parser->toString(node2);
     std::cout << "  (/ 7 3) -> " << s2 << std::endl;
-    assert(node2->getValue()->getNumberValue().toRationalExact() ==
+    VERIFY(node2->getValue()->getNumberValue().toRationalExact() ==
            HighPrecisionRational("7/3"));
 
     // (/ 10 2) -> 5
     auto node3 = parser->mkExpr("(/ 10 2)");
-    assert(node3 != nullptr);
-    assert(node3->isCReal());
+    VERIFY(node3 != nullptr);
+    VERIFY(node3->isCReal());
     std::string s3 = parser->toString(node3);
     std::cout << "  (/ 10 2) -> " << s3 << std::endl;
-    assert(node3->getValue()->getNumberValue().asIntegerExact() == Integer(5));
+    VERIFY(node3->getValue()->getNumberValue().asIntegerExact() == Integer(5));
 
     // (/ -1 10)
     auto node4 = parser->mkExpr("(/ -1 10)");
-    assert(node4 != nullptr);
-    assert(node4->isCReal());
+    VERIFY(node4 != nullptr);
+    VERIFY(node4->isCReal());
     std::string s4 = parser->toString(node4);
     std::cout << "  (/ -1 10) -> " << s4 << std::endl;
-    assert(node4->getValue()->getNumberValue().toRationalExact() ==
+    VERIFY(node4->getValue()->getNumberValue().toRationalExact() ==
            HighPrecisionRational("-1/10"));
 
     // (/ 0 10) -> 0
     auto node5 = parser->mkExpr("(/ 0 10)");
-    assert(node5 != nullptr);
-    assert(node5->isCReal());
+    VERIFY(node5 != nullptr);
+    VERIFY(node5->isCReal());
     std::string s5 = parser->toString(node5);
     std::cout << "  (/ 0 10) -> " << s5 << std::endl;
-    assert(s5 == "0");
+    VERIFY(s5 == "0");
 
     // nested: (+ (/ 1 10) (/ 2 10))
     auto node6 = parser->mkExpr("(+ (/ 1 10) (/ 2 10))");
-    assert(node6 != nullptr);
+    VERIFY(node6 != nullptr);
     std::string s6 = parser->toString(node6);
     std::cout << "  (+ (/ 1 10) (/ 2 10)) -> " << s6 << std::endl;
-    assert(node6->getValue()->getNumberValue().toRationalExact() ==
+    VERIFY(node6->getValue()->getNumberValue().toRationalExact() ==
            HighPrecisionRational("3/10"));
 
     std::cout << "  Parser constant folding OK" << std::endl;
@@ -207,25 +207,25 @@ void test_parser_decimal_to_rational() {
     ParserPtr parser = newParser();
 
     auto node1 = parser->mkExpr("59.01938237");
-    assert(node1 != nullptr);
-    assert(node1->isCReal());
+    VERIFY(node1 != nullptr);
+    VERIFY(node1->isCReal());
     std::string s1 = parser->toString(node1);
     std::cout << "  59.01938237 -> " << s1 << std::endl;
-    assert(node1->getValue()->getNumberValue().toRationalExact() ==
+    VERIFY(node1->getValue()->getNumberValue().toRationalExact() ==
            HighPrecisionRational("5901938237/100000000"));
 
     auto node2 = parser->mkExpr("0.125");
-    assert(node2 != nullptr);
+    VERIFY(node2 != nullptr);
     std::string s2 = parser->toString(node2);
     std::cout << "  0.125 -> " << s2 << std::endl;
-    assert(node2->getValue()->getNumberValue().toRationalExact() ==
+    VERIFY(node2->getValue()->getNumberValue().toRationalExact() ==
            HighPrecisionRational("1/8"));
 
     auto node3 = parser->mkExpr("-2.5");
-    assert(node3 != nullptr);
+    VERIFY(node3 != nullptr);
     std::string s3 = parser->toString(node3);
     std::cout << "  -2.5 -> " << s3 << std::endl;
-    assert(node3->getValue()->getNumberValue().toRationalExact() ==
+    VERIFY(node3->getValue()->getNumberValue().toRationalExact() ==
            HighPrecisionRational("-5/2"));
 
     std::cout << "  Decimal to rational OK" << std::endl;
@@ -238,12 +238,12 @@ void test_transcendental_fallback() {
     Number n(std::string("2.0"));
     Number s = n.sin();
     (void)s;
-    assert(s.isReal());
+    VERIFY(s.isReal());
     std::cout << "  sin(2.0) type=" << s.getType() << " str=" << s.toString() << std::endl;
 
     Number e = n.exp();
     (void)e;
-    assert(e.isReal());
+    VERIFY(e.isReal());
     std::cout << "  exp(2.0) type=" << e.getType() << " str=" << e.toString() << std::endl;
 
     std::cout << "  Transcendental fallback OK" << std::endl;
@@ -256,29 +256,29 @@ void test_dump_smtlib2_rational() {
     auto n1 = parser->mkExpr("(/ 1 10)");
     std::string s1 = dumpSMTLIB2(n1);
     std::cout << "  (/ 1 10) -> " << s1 << std::endl;
-    assert(s1 == "(/ 1 10)");
+    VERIFY(s1 == "(/ 1 10)");
 
     auto n2 = parser->mkExpr("(/ 7 3)");
     std::string s2 = dumpSMTLIB2(n2);
     std::cout << "  (/ 7 3) -> " << s2 << std::endl;
-    assert(s2 == "(/ 7 3)");
+    VERIFY(s2 == "(/ 7 3)");
 
     auto n3 = parser->mkExpr("(/ -1 10)");
     std::string s3 = dumpSMTLIB2(n3);
     std::cout << "  (/ -1 10) -> " << s3 << std::endl;
-    assert(s3 == "(- (/ 1 10))");
+    VERIFY(s3 == "(- (/ 1 10))");
 
     // Decimal literals are emitted as exact SMT-LIB rational terms.
     auto n4 = parser->mkExpr("0.125");
     std::string s4 = dumpSMTLIB2(n4);
     std::cout << "  0.125 -> " << s4 << std::endl;
-    assert(s4 == "(/ 1 8)");
+    VERIFY(s4 == "(/ 1 8)");
 
     // Negative decimal literal
     auto n5 = parser->mkExpr("-2.5");
     std::string s5 = dumpSMTLIB2(n5);
     std::cout << "  -2.5 -> " << s5 << std::endl;
-    assert(s5 == "(- (/ 5 2))");
+    VERIFY(s5 == "(- (/ 5 2))");
 
     std::cout << "  dumpSMTLIB2 rational output OK" << std::endl;
 }
@@ -286,14 +286,14 @@ void test_dump_smtlib2_rational() {
 void test_type_checker_is_real() {
     std::cout << "=== TypeChecker::isReal ===" << std::endl;
 
-    assert(TypeChecker::isReal("3.14159"));
-    assert(TypeChecker::isReal("42"));
-    assert(TypeChecker::isReal("1/2"));
-    assert(TypeChecker::isReal("-7/3"));
-    assert(!TypeChecker::isReal("1/0"));  // denominator zero rejected
-    assert(!TypeChecker::isReal("abc"));
-    assert(!TypeChecker::isReal("1.2.3"));
-    assert(!TypeChecker::isReal("1/2/3"));
+    VERIFY(TypeChecker::isReal("3.14159"));
+    VERIFY(TypeChecker::isReal("42"));
+    VERIFY(TypeChecker::isReal("1/2"));
+    VERIFY(TypeChecker::isReal("-7/3"));
+    VERIFY(!TypeChecker::isReal("1/0"));  // denominator zero rejected
+    VERIFY(!TypeChecker::isReal("abc"));
+    VERIFY(!TypeChecker::isReal("1.2.3"));
+    VERIFY(!TypeChecker::isReal("1/2/3"));
 
     std::cout << "  TypeChecker::isReal OK" << std::endl;
 }

--- a/test/theory/test_string_handling.cpp
+++ b/test/theory/test_string_handling.cpp
@@ -2,7 +2,7 @@
 #include <string>
 #include <vector>
 #include "somtparser/frontend/parser.h"
-#include <cassert>
+#include "test_helpers.h"
 
 // Test strings of different lengths
 void test_string_lengths(SOMTParser::ParserPtr& parser) {
@@ -18,7 +18,7 @@ void test_string_lengths(SOMTParser::ParserPtr& parser) {
     for (const auto& str : test_strings) {
         std::cout << "Testing string length: " << str.length() << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkConstStr(str);
-        assert(result && !result->isErr());
+        VERIFY(result && !result->isErr());
         std::cout << "  Result: " << parser->toString(result) << std::endl;
     }
 }
@@ -35,7 +35,7 @@ void test_special_chars(SOMTParser::ParserPtr& parser) {
     for (const auto& str : test_strings) {
         std::cout << "Testing special character: " << str << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(str);
-        assert(result && !result->isErr());
+        VERIFY(result && !result->isErr());
         std::cout << "  Result: " << parser->toString(result) << std::endl;
     }
 }

--- a/test/theory/test_string_operations.cpp
+++ b/test/theory/test_string_operations.cpp
@@ -2,7 +2,7 @@
 #include <string>
 #include <vector>
 #include "somtparser/frontend/parser.h"
-#include <cassert>
+#include "test_helpers.h"
 
 // Test string constants
 void test_string_constants(SOMTParser::ParserPtr& parser) {
@@ -42,7 +42,7 @@ cvc5:
     for (const auto& expr : expressions) {
         std::cout << "Expression: " << expr << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(expr);
-        assert(result && !result->isErr());
+        VERIFY(result && !result->isErr());
         std::cout << "  Result: " << parser->toString(result) << std::endl;
         std::cout << std::endl;
     }
@@ -66,7 +66,7 @@ void test_string_operations(SOMTParser::ParserPtr& parser) {
     for (const auto& expr : expressions) {
         std::cout << "Expression: " << expr << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(expr);
-        assert(result && !result->isErr());
+        VERIFY(result && !result->isErr());
         std::cout << "  Result: " << parser->toString(result) << std::endl;
         std::cout << std::endl;
     }
@@ -87,8 +87,8 @@ void test_string_comparisons(SOMTParser::ParserPtr& parser) {
     for (const auto& expr : expressions) {
         std::cout << "Expression: " << expr << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(expr);
-        assert(result && !result->isErr());
-        assert(result->isTrue() || result->isFalse());
+        VERIFY(result && !result->isErr());
+        VERIFY(result->isTrue() || result->isFalse());
         std::cout << "  Result: " << parser->toString(result) << std::endl;
         std::cout << std::endl;
     }
@@ -108,7 +108,7 @@ void test_regex_operations(SOMTParser::ParserPtr& parser) {
     for (const auto& expr : expressions) {
         std::cout << "Expression: " << expr << std::endl;
         std::shared_ptr<SOMTParser::DAGNode> result = parser->mkExpr(expr);
-        assert(result && !result->isErr());
+        VERIFY(result && !result->isErr());
         std::cout << "  Result: " << parser->toString(result) << std::endl;
         std::cout << std::endl;
     }


### PR DESCRIPTION
Follow-up to the note left in #44, scoped after measuring. Independent of that PR — this branch is cut from `main`.

## The problem

`CMakeLists.txt` forces **Release** as the default build type for a top-level build, and Release adds `-DNDEBUG`. Test targets inherit it (confirmed in `flags.make`: `CXX_FLAGS = -O3 -DNDEBUG`), so the ordinary local path

```
cmake -S . -B build -DSOMTPARSER_BUILD_TESTS=ON && ctest
```

compiled **all 717 `assert()` calls in the suite away** — 32 of 37 test files.

**CI was never affected**: `test/run_all_tests.sh` uses `CMAKE_BUILD_TYPE=Debug`, so assertions fire there. The blind spot was the default developer path.

## Why it mattered

Most assertions merely stopped checking. The harmful class is the **29 assertions across 4 files whose expression performs the work being tested**:

```cpp
assert(parser.parseStr("(minimize x)"));   // under NDEBUG: never called
```

| file | such asserts |
|---|---|
| `integration/test_optimization.cpp` | 19 |
| `integration/test_options_config.cpp` | 7 |
| `parser/test_parse_oper_builtin_priority.cpp` | 2 |
| `api/test_uf_model_api.cpp` | 1 |

A Release build of `test_optimization` on `main` printed:

```
  Objectives: 0, first is minimize, term present.
  ✓ minimize test passed
```

It reported success while holding **zero** objectives — the `parseStr` calls never ran, and the assertions that would have caught it were gone too. Note that had those assertions run, `objs[0]` on an empty vector would have been undefined behaviour; the test was only "passing" because both halves were deleted together.

Same build, `test_options_config` Test 4 reported logic `UNKNOWN_LOGIC` right after "asserting" it had set `QF_UFLIA`.

After this PR, Release prints `Objectives: 1, first is minimize, term present.`

## The change

**Commit 1** — convert all 717 call sites to `VERIFY` from `test/test_helpers.h`, which the repo already provides for exactly this and documents as *"NDEBUG-safe assertion for side-effectful expressions"*. It was in use in only 3 files. Adds the include where missing, drops `<cassert>` where it became unused.

The rewrite used a scanner that skips string literals and comments, not a blind substitution: the suite embeds **57 SMT-LIB `(assert ...)` fragments** inside test-input strings that must survive untouched. Verified afterwards that this count is unchanged, that no `assert(` remains outside a comment, and that no diff line altered a string literal.

**Commit 2** — compile test targets with `-UNDEBUG` (`/UNDEBUG` on MSVC). Converting today's call sites does not stop a new test from reaching for `assert()` again, which is the natural thing to write. This keeps `assert()` live in every configuration regardless.

Safe against ODR mismatch with `libsomtparser`: **no header or source under `include/` or `src/` is NDEBUG-conditional** (checked), and `condAssert` is defined unconditionally as a `throw`. The flag changes nothing but `assert()` in the test translation units. Verified with the exact resulting flags (`-O3 -DNDEBUG -UNDEBUG`) that a false assert aborts.

## Testing

No test was hiding a real failure — the assertions were correct, just inert.

| configuration | result |
|---|---|
| Release (`-O3 -DNDEBUG -UNDEBUG`), assertions now live | **36/36** |
| Debug (what CI runs) | **36/36** |

Diff is large but almost entirely mechanical: 717 of the changed lines are the `assert` → `VERIFY` token.

## Merge order with #44

Verified by actually merging both branches into `main` locally rather than predicting it:

- **No conflict.** git auto-merges `test/integration/test_options_config.cpp` — #44 adds a new test block, this PR rewrites the pre-existing assertions, and the two touch disjoint lines.
- The one artifact is a **duplicate `#include "test_helpers.h"`** (both branches add it independently). Harmless — the header has an include guard — but the second merge should delete the extra line.
- Merged result verified: **37/37 in Release** (assertions live) and **37/37 in Debug**.
- No stray `assert(` survives the merge; the sole textual match left in the tree is inside a comment.

Either order works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)