### PR TITLE
Make the popLetScope precondition hold in Release builds

### DIFF
--- a/src/frontend/symbol_manager.cpp
+++ b/src/frontend/symbol_manager.cpp
@@ -3,8 +3,8 @@
  */
 
 #include "somtparser/frontend/symbol_manager.h"
+#include "somtparser/core/asserting.h"
 #include <algorithm>
-#include <cassert>
 
 namespace SOMTParser {
 
@@ -122,7 +122,12 @@ void SymbolManager::pushLetScope() {
 }
 
 void SymbolManager::popLetScope() {
-    assert(!let_scope_checkpoints_.empty() && "popLetScope: no checkpoint to pop");
+    // condAssert, not assert: the library is compiled with -DNDEBUG in the
+    // default Release build, where assert() is a no-op -- and the two lines
+    // below would then read and pop an empty vector, which is undefined
+    // behaviour. condAssert throws unconditionally, so an unbalanced pop
+    // surfaces as a diagnosable error in every configuration.
+    condAssert(!let_scope_checkpoints_.empty(), "popLetScope: no checkpoint to pop");
     size_t checkpoint = let_scope_checkpoints_.back();
     let_scope_checkpoints_.pop_back();
     // Restore from the end of backup list back to checkpoint

--- a/test/regression/test_let_scope_guard.cpp
+++ b/test/regression/test_let_scope_guard.cpp
@@ -1,0 +1,82 @@
+// SymbolManager::popLetScope() reads and pops let_scope_checkpoints_.  Its
+// precondition used to be stated with assert(), which the default Release
+// build (-DNDEBUG) removes, leaving .back()/.pop_back() on a possibly empty
+// vector -- undefined behaviour in exactly the configuration that ships.
+//
+// It now uses condAssert, which throws unconditionally.  These tests pin that
+// an unbalanced pop is diagnosed in every build type, and that the balanced
+// path is unaffected.
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include "somtparser/frontend/symbol_manager.h"
+#include "test_helpers.h"
+
+using namespace SOMTParser;
+
+int main() {
+    std::cout << "======= let scope guard tests =======\n";
+
+    // Balanced use: a binding registered inside a scope disappears with it.
+    {
+        SymbolManager sm;
+        sm.pushLetScope();
+        sm.registerLet("x", nullptr);
+        VERIFY(sm.hasLet("x"));
+        sm.popLetScope();
+        VERIFY(!sm.hasLet("x"));
+        std::cout << "  ok: balanced push/pop restores the outer scope\n";
+    }
+
+    // Nested scopes: the inner pop must only undo the inner bindings.
+    {
+        SymbolManager sm;
+        sm.pushLetScope();
+        sm.registerLet("outer", nullptr);
+        sm.pushLetScope();
+        sm.registerLet("inner", nullptr);
+        VERIFY(sm.hasLet("outer") && sm.hasLet("inner"));
+        sm.popLetScope();
+        VERIFY(sm.hasLet("outer") && !sm.hasLet("inner"));
+        sm.popLetScope();
+        VERIFY(!sm.hasLet("outer"));
+        std::cout << "  ok: nested pop only undoes the inner scope\n";
+    }
+
+    // Unbalanced pop: a diagnosable error, not undefined behaviour.  The
+    // library is compiled with -DNDEBUG in Release, so this only holds because
+    // the check is a condAssert rather than an assert.
+    {
+        SymbolManager sm;
+        bool threw = false;
+        try {
+            sm.popLetScope();
+        } catch (const std::exception& e) {
+            threw = true;
+            const std::string msg = e.what();
+            VERIFY(msg.find("popLetScope") != std::string::npos);
+        }
+        VERIFY(threw);
+        std::cout << "  ok: pop without a matching push throws\n";
+    }
+
+    // One pop too many after a balanced pair must also be caught.
+    {
+        SymbolManager sm;
+        sm.pushLetScope();
+        sm.popLetScope();
+        bool threw = false;
+        try {
+            sm.popLetScope();
+        } catch (const std::exception&) {
+            threw = true;
+        }
+        VERIFY(threw);
+        std::cout << "  ok: extra pop after a balanced pair throws\n";
+    }
+
+    std::cout << "All let scope guard tests passed.\n";
+    return 0;
+}

--- a/test/regression/test_let_scope_guard.cpp
+++ b/test/regression/test_let_scope_guard.cpp
@@ -11,10 +11,36 @@
 #include <stdexcept>
 #include <string>
 
+#include "somtparser/frontend/parser.h"
 #include "somtparser/frontend/symbol_manager.h"
 #include "test_helpers.h"
 
 using namespace SOMTParser;
+
+namespace {
+
+// The invariant the guard protects is maintained by base_parser: each
+// pushLetScope() is undone through the per-frame scope_pushed flag, including
+// on the error exits. Those exits are the interesting ones -- a let that fails
+// mid-binding must still leave the symbol table balanced -- so drive them
+// through the parser rather than only unit-testing SymbolManager.
+void parseErrorLeavesParserUsable(const char* label, const std::string& script) {
+    ParserPtr p = newParser();
+    try {
+        p->parseStr(script);
+    } catch (const std::exception&) {
+        // Reporting the malformed input is fine; leaking a let scope is not.
+    }
+    // A well-formed let afterwards must still bind, print and unbind normally.
+    auto node = p->mkExpr("(let ((y 1)) y)");
+    VERIFY(node && !node->isErr());
+    VERIFY(p->toString(node) == "(let ((y 1)) y)");
+    // And the binding must not have escaped its scope.
+    VERIFY(!p->getSymbolManager()->hasLet("y"));
+    std::cout << "  ok: " << label << "\n";
+}
+
+}  // namespace
 
 int main() {
     std::cout << "======= let scope guard tests =======\n";
@@ -75,6 +101,27 @@ int main() {
         }
         VERIFY(threw);
         std::cout << "  ok: extra pop after a balanced pair throws\n";
+    }
+
+    // The parser-level error exits that pop the scopes they pushed.
+    parseErrorLeavesParserUsable(
+        "duplicate binding in one let leaves the scope balanced",
+        "(declare-fun a () Int)\n(assert (= a (let ((x 1) (x 2)) x)))\n");
+    parseErrorLeavesParserUsable(
+        "failure inside a binding value leaves the scope balanced",
+        "(declare-fun a () Int)\n(assert (= a (let ((x (undefined_fn 1))) x)))\n");
+    parseErrorLeavesParserUsable(
+        "failure inside a nested let leaves both scopes balanced",
+        "(declare-fun a () Int)\n"
+        "(assert (= a (let ((x 1)) (let ((z (undefined_fn x))) z))))\n");
+
+    // The success path still nests correctly after all of the above.
+    {
+        ParserPtr p = newParser();
+        p->parseStr("(declare-fun a () Int)\n(assert (= a (let ((x 1)) (let ((y x)) y))))\n");
+        VERIFY(p->getAssertions().size() == 1);
+        VERIFY(!p->getSymbolManager()->hasLet("x") && !p->getSymbolManager()->hasLet("y"));
+        std::cout << "  ok: nested let parses and unbinds both scopes\n";
     }
 
     std::cout << "All let scope guard tests passed.\n";


### PR DESCRIPTION
Third and last item from the audit behind #44 / #45. Independent of both — cut from `main`, one library line plus a test.

## The problem

`SymbolManager::popLetScope()` stated its precondition with `assert()`:

```cpp
assert(!let_scope_checkpoints_.empty() && "popLetScope: no checkpoint to pop");
size_t checkpoint = let_scope_checkpoints_.back();   // empty vector -> UB
let_scope_checkpoints_.pop_back();                   // empty vector -> UB
```

`CMakeLists.txt` makes **Release** the default build type, and Release defines `NDEBUG`. So in the configuration that actually ships, the guard is gone and the next two lines read and pop an empty vector. The garbage `checkpoint` then reaches `let_scope_backup_.resize(checkpoint)`.

Built against the pre-fix library, the new test **segfaults** (exit 139) — the assertion meant to prevent exactly this had been compiled out. After the fix it passes.

## The fix

Use `condAssert`, which the rest of the library already uses and which throws unconditionally, so an unbalanced pop is a diagnosable error in every configuration instead of memory corruption in the shipping one.

## Scope and severity

**This is hardening, not a live bug fix.** Every `popLetScope()` call site in `base_parser.cpp` is paired with a `pushLetScope()` through the per-frame `scope_pushed` flag, so the invariant holds today; the full suite in Debug — where the original `assert` was live — never tripped it. The point is the failure mode if that bookkeeping ever breaks: an exception, not UB.

## Deliberately not changed

The other raw `assert()` in the library, `op_dispatcher.h:100`:

```cpp
assert(false && "OpDispatcher: unhandled NODE_KIND");
if constexpr (!std::is_void_v<Result>) { return Result{}; }
```

That one is by design — a debug-only check with a defined `Result{}` fallback and no UB behind it. Changing it would be a behaviour change, so it stays.

## Testing

New `test/regression/test_let_scope_guard.cpp` covers the balanced path (a binding registered inside a scope disappears with it), nested scopes (an inner pop undoes only the inner bindings), and both unbalanced cases (pop with no push; one pop too many).

Failure-before / pass-after was verified, not assumed: the test was run against a build of the pre-fix library — segfault — and against the fixed one — clean pass. (The UB run was done under `ulimit -v` and a `timeout` so a runaway `resize` could not take the machine down.)

| configuration | result |
|---|---|
| Release | **37/37** |
| Debug | **37/37** |

## Relationship to #44 / #45

No file overlap with either, so no merge ordering constraint. #45 undefines `NDEBUG` for *test* targets; the library keeps `-DNDEBUG`, which is why this call site still needed fixing at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)