### PR TITLE
Make dumpSMT2 output readable by this parser again

### DIFF
--- a/include/somtparser/frontend/symbol_manager.h
+++ b/include/somtparser/frontend/symbol_manager.h
@@ -110,6 +110,16 @@ public:
     const std::unordered_map<std::string, std::shared_ptr<Sort>>& getSortKeyMap() const;
     void removeFun(const std::string& name);
 
+    // Declaration order. The maps above are unordered, so iterating them gives
+    // an order unrelated to the input -- which makes anything derived from it
+    // (notably dumpSMT2) irreproducible. These record first-registration order,
+    // mirroring how function_names_ already tracks functions. Names removed
+    // from the corresponding map are left in place and must be skipped by the
+    // caller via the map lookup.
+    const std::vector<std::string>& getSortOrder() const;
+    const std::vector<std::string>& getVarOrder() const;
+    const std::vector<std::string>& getTempVarOrder() const;
+
 private:
     struct LetBackup {
         std::string name;
@@ -129,6 +139,9 @@ private:
     std::unordered_map<std::string, std::shared_ptr<DAGNode>> placeholder_var_names_;
     std::vector<std::string> function_names_;
     std::vector<std::shared_ptr<DAGNode>> static_functions_;
+    std::vector<std::string> sort_order_;
+    std::vector<std::string> var_order_;
+    std::vector<std::string> temp_var_order_;
 };
 
 } // namespace SOMTParser

--- a/src/frontend/base_parser.cpp
+++ b/src/frontend/base_parser.cpp
@@ -257,18 +257,30 @@ namespace SOMTParser{
 	void Parser::setOption(const std::string& key, const bool& value){
 		getOptions()->setOption(key, value?"true":"false");
 	}
+	// Declaration order, not hash order: these feed dumpSMT2, and iterating the
+	// underlying unordered_map produced a variable order unrelated to the input,
+	// so dumping a query and re-parsing it did not converge.
 	std::vector<std::shared_ptr<DAGNode>> Parser::getVariables() const{
 		std::vector<std::shared_ptr<DAGNode>> vars;
-		for(const auto& var : getSymbolManager()->getVarNames())
-			vars.emplace_back(var.second);
-		for(const auto& var : getSymbolManager()->getTempVarNames())
-			vars.emplace_back(var.second);
+		const auto& var_names = getSymbolManager()->getVarNames();
+		for(const auto& name : getSymbolManager()->getVarOrder()){
+			auto it = var_names.find(name);
+			if(it != var_names.end()) vars.emplace_back(it->second);
+		}
+		const auto& temp_names = getSymbolManager()->getTempVarNames();
+		for(const auto& name : getSymbolManager()->getTempVarOrder()){
+			auto it = temp_names.find(name);
+			if(it != temp_names.end()) vars.emplace_back(it->second);
+		}
 		return vars;
 	}
 	std::vector<std::shared_ptr<DAGNode>> Parser::getDeclaredVariables() const{
 		std::vector<std::shared_ptr<DAGNode>> vars;
-		for(const auto& var : getSymbolManager()->getVarNames())
-			vars.emplace_back(var.second);
+		const auto& var_names = getSymbolManager()->getVarNames();
+		for(const auto& name : getSymbolManager()->getVarOrder()){
+			auto it = var_names.find(name);
+			if(it != var_names.end()) vars.emplace_back(it->second);
+		}
 		return vars;
 	}
 
@@ -3441,11 +3453,46 @@ namespace SOMTParser{
 
 	std::string Parser::dumpSMT2(){
 		std::stringstream ss;
-		ss << "(set-logic " << getOptions()->getLogic() << ")" << std::endl;
-		// custom sorts
-		for(const auto& sort_pair : getSymbolManager()->getSortKeyMap()){
-			if(sort_pair.second->isDec()){
-				ss << "(declare-sort " << sort_pair.first << " " << sort_pair.second->arity << ")" << std::endl;
+		// An input without (set-logic ...) leaves the logic at the placeholder
+		// UNKNOWN_LOGIC, which is not a logic name any parser accepts -- ours
+		// included -- so emitting it made every such dump unreadable. Fall back
+		// to ALL, which is what "no logic was stated" means for a dump.
+		const std::string logic = getOptions()->getLogic();
+		ss << "(set-logic " << (logic == "UNKNOWN_LOGIC" ? "ALL" : logic) << ")" << std::endl;
+		// custom sorts, in declaration order (getSortKeyMap is unordered)
+		const auto& sort_map = getSymbolManager()->getSortKeyMap();
+		// Names introduced by a datatype declaration: its constructors, their
+		// selectors and the derived testers. (declare-datatypes ...) already
+		// declares all of them, so emitting a declare-fun for each as well
+		// would make the dump reject itself as a redeclaration.
+		std::unordered_set<std::string> datatype_member_names;
+		for(const auto& sort_name : getSymbolManager()->getSortOrder()){
+			auto it = sort_map.find(sort_name);
+			if(it == sort_map.end() || !it->second) continue;
+			const auto& sort = it->second;
+			if(sort->isDec()){
+				ss << "(declare-sort " << sort_name << " " << sort->arity << ")" << std::endl;
+			}
+			else if(sort->isDatatype() && sort->hasDtConstructors()){
+				// (declare-datatypes ((T 0)) (((ctor (sel S) ...) ...)))
+				// Without this the constructors were dumped as plain
+				// declare-funs over a sort that was never declared, so no
+				// datatype query could survive a dump/re-parse cycle.
+				ss << "(declare-datatypes ((" << sort_name << " " << sort->arity << ")) ((";
+				bool first_ctor = true;
+				for(const auto& ctor : sort->getDtConstructors()){
+					if(!first_ctor) ss << " ";
+					first_ctor = false;
+					datatype_member_names.insert(ctor.name);
+					datatype_member_names.insert("is-" + ctor.name);
+					ss << "(" << ctor.name;
+					for(const auto& sel : ctor.selectors){
+						datatype_member_names.insert(sel.name);
+						ss << " (" << sel.name << " " << sel.sort->toString() << ")";
+					}
+					ss << ")";
+				}
+				ss << ")))" << std::endl;
 			}
 		}
 		// variables
@@ -3455,6 +3502,8 @@ namespace SOMTParser{
 		}
 	std::vector<std::shared_ptr<DAGNode>> functions = getFunctions();
 	for(auto& func : functions){
+		if(!func) continue;
+		if(datatype_member_names.count(func->getName())) continue;
 		if(func->isFuncDec()){
 			// NT_FUNC_DEC: Uninterpreted function declaration (declare-fun)
 			ss << dumpFuncDec(func) << std::endl;

--- a/src/frontend/symbol_manager.cpp
+++ b/src/frontend/symbol_manager.cpp
@@ -185,6 +185,7 @@ bool SymbolManager::hasFunVar(const std::string& name) const {
 }
 
 void SymbolManager::registerSort(const std::string& name, const std::shared_ptr<Sort>& sort) {
+    if (sort_key_map_.find(name) == sort_key_map_.end()) sort_order_.push_back(name);
     sort_key_map_[name] = sort;
 }
 
@@ -214,6 +215,7 @@ bool SymbolManager::hasQuantVar(const std::string& name) const {
 }
 
 void SymbolManager::registerVar(const std::string& name, const std::shared_ptr<DAGNode>& node) {
+    if (var_names_.find(name) == var_names_.end()) var_order_.push_back(name);
     var_names_[name] = node;
 }
 
@@ -248,6 +250,7 @@ size_t SymbolManager::nextTempVarCounter() {
 }
 
 void SymbolManager::registerTempVar(const std::string& name, const std::shared_ptr<DAGNode>& node) {
+    if (temp_var_names_.find(name) == temp_var_names_.end()) temp_var_order_.push_back(name);
     temp_var_names_[name] = node;
 }
 
@@ -319,6 +322,18 @@ void SymbolManager::addStaticFunction(const std::shared_ptr<DAGNode>& node) {
 
 const std::vector<std::shared_ptr<DAGNode>>& SymbolManager::getStaticFunctions() const {
     return static_functions_;
+}
+
+const std::vector<std::string>& SymbolManager::getSortOrder() const {
+    return sort_order_;
+}
+
+const std::vector<std::string>& SymbolManager::getVarOrder() const {
+    return var_order_;
+}
+
+const std::vector<std::string>& SymbolManager::getTempVarOrder() const {
+    return temp_var_order_;
 }
 
 const std::unordered_map<std::string, std::shared_ptr<Sort>>& SymbolManager::getSortKeyMap() const {

--- a/test/regression/test_dump_reparse.cpp
+++ b/test/regression/test_dump_reparse.cpp
@@ -1,0 +1,164 @@
+// dumpSMT2() must emit a script this parser can read back, and reading it back
+// must produce the same script again.  Three defects broke that:
+//
+//   * datatypes were dumped as plain declare-funs over a sort that was never
+//     declared, so re-parsing failed on the undeclared sort name;
+//   * declarations were emitted in unordered_map iteration order, so
+//     dump -> parse -> dump did not converge;
+//   * an input without (set-logic ...) dumped the placeholder UNKNOWN_LOGIC,
+//     which is not a logic name any parser accepts.
+//
+// The cases below deliberately avoid operators whose printing is fixed
+// elsewhere, so this file stands on its own.
+
+#include <iostream>
+#include <string>
+
+#include "somtparser/frontend/parser.h"
+#include "test_helpers.h"
+
+using namespace SOMTParser;
+
+namespace {
+
+// Dump, re-parse the dump, dump again; require a fixed point.  Returns it.
+std::string dumpFixedPoint(const std::string& label, const std::string& script) {
+    ParserPtr p = newParser();
+    p->parseStr(script);
+    const std::string once = p->dumpSMT2();
+
+    ParserPtr q = newParser();
+    q->parseStr(once);  // must not reject our own output
+    const std::string twice = q->dumpSMT2();
+
+    if (once != twice) {
+        std::cerr << "FAILED " << label << ": dump is not a fixed point\n"
+                  << "--- first ---\n" << once << "--- second ---\n" << twice;
+        std::abort();
+    }
+    std::cout << "  ok: " << label << "\n";
+    return once;
+}
+
+void expectContains(const std::string& what, const std::string& hay, const std::string& needle) {
+    if (hay.find(needle) == std::string::npos) {
+        std::cerr << "FAILED " << what << ": expected to find\n  " << needle
+                  << "\nin\n" << hay;
+        std::abort();
+    }
+}
+
+void expectAbsent(const std::string& what, const std::string& hay, const std::string& needle) {
+    if (hay.find(needle) != std::string::npos) {
+        std::cerr << "FAILED " << what << ": did not expect\n  " << needle
+                  << "\nin\n" << hay;
+        std::abort();
+    }
+}
+
+// ── A datatype must be dumped as a datatype. ──────────────────────────────
+void test_datatype_dump() {
+    std::cout << "-- datatype declarations --\n";
+    const std::string dump = dumpFixedPoint(
+        "datatype round trip",
+        "(declare-datatypes ((L 0)) (((nil) (cons (hd Int) (tl L)))))\n"
+        "(declare-fun l () L)\n"
+        "(assert (= 1 (hd (cons 1 nil))))\n");
+
+    expectContains("datatype declaration is emitted", dump,
+                   "(declare-datatypes ((L 0)) (((nil) (cons (hd Int) (tl L)))))");
+    // The constructors, selectors and testers come with the datatype; a
+    // declare-fun for any of them would be a redeclaration on re-parse.
+    expectAbsent("constructor is not also declared", dump, "(declare-fun nil ");
+    expectAbsent("constructor is not also declared", dump, "(declare-fun cons ");
+    expectAbsent("selector is not also declared", dump, "(declare-fun hd ");
+    expectAbsent("selector is not also declared", dump, "(declare-fun tl ");
+    expectAbsent("tester is not also declared", dump, "(declare-fun is-nil ");
+    // The datatype-sorted variable is still declared normally.
+    expectContains("variable of datatype sort is declared", dump, "(declare-fun l () L)");
+    std::cout << "  ok: constructors/selectors/testers are not re-declared\n";
+
+    // Several constructors each carrying selectors.
+    dumpFixedPoint("multi-constructor datatype",
+                   "(declare-datatypes ((P 0)) (((mk (fst Int) (snd Bool)) (none))))\n"
+                   "(declare-fun p () P)\n(assert (= p (mk 1 true)))\n");
+}
+
+// ── Declaration order must follow the input, not a hash. ──────────────────
+void test_declaration_order_is_stable() {
+    std::cout << "-- declaration order --\n";
+    const std::string dump = dumpFixedPoint(
+        "declaration order round trip",
+        "(declare-fun x () (_ BitVec 8))\n"
+        "(declare-fun i () Int)\n"
+        "(declare-fun a () Bool)\n"
+        "(declare-fun s () String)\n"
+        "(assert a)\n");
+
+    const size_t px = dump.find("(declare-fun x ");
+    const size_t pi = dump.find("(declare-fun i ");
+    const size_t pa = dump.find("(declare-fun a ");
+    const size_t ps = dump.find("(declare-fun s ");
+    VERIFY(px != std::string::npos && pi != std::string::npos);
+    VERIFY(pa != std::string::npos && ps != std::string::npos);
+    if (!(px < pi && pi < pa && pa < ps)) {
+        std::cerr << "FAILED declarations are not in input order:\n" << dump;
+        std::abort();
+    }
+    std::cout << "  ok: declarations follow input order\n";
+
+    // Two parsers fed the same text must produce byte-identical dumps.
+    const std::string script =
+        "(declare-fun b () Bool)\n(declare-fun c () Int)\n(declare-fun d () Real)\n(assert b)\n";
+    ParserPtr p1 = newParser();
+    p1->parseStr(script);
+    ParserPtr p2 = newParser();
+    p2->parseStr(script);
+    VERIFY(p1->dumpSMT2() == p2->dumpSMT2());
+    std::cout << "  ok: the same input dumps identically twice\n";
+}
+
+// ── Uninterpreted sorts and functions. ────────────────────────────────────
+void test_declare_sort_and_functions() {
+    std::cout << "-- declare-sort / functions --\n";
+    const std::string dump = dumpFixedPoint(
+        "declare-sort round trip",
+        "(declare-sort U 0)\n(declare-fun u () U)\n(declare-fun f (U) Bool)\n(assert (f u))\n");
+    expectContains("sort declaration is emitted", dump, "(declare-sort U 0)");
+    expectContains("uninterpreted function is emitted", dump, "(declare-fun f ");
+
+    dumpFixedPoint("define-fun round trip",
+                   "(define-fun double ((n Int)) Int (* 2 n))\n"
+                   "(declare-fun k () Int)\n(assert (= (double k) 4))\n");
+}
+
+// ── The logic line must be a logic. ───────────────────────────────────────
+void test_logic_line_is_parsable() {
+    std::cout << "-- set-logic line --\n";
+    ParserPtr p = newParser();
+    p->parseStr("(declare-fun q () Bool)\n(assert q)\n");  // no (set-logic ...)
+    const std::string dump = p->dumpSMT2();
+    expectAbsent("placeholder logic is never emitted", dump, "UNKNOWN_LOGIC");
+    // And whatever it does emit has to be readable.
+    ParserPtr q = newParser();
+    q->parseStr(dump);
+    std::cout << "  ok: a script without set-logic dumps a parsable logic\n";
+
+    // An explicitly stated logic survives unchanged.
+    const std::string with_logic = dumpFixedPoint(
+        "explicit logic round trip",
+        "(set-logic QF_LIA)\n(declare-fun n () Int)\n(assert (> n 0))\n");
+    expectContains("stated logic is preserved", with_logic, "(set-logic QF_LIA)");
+}
+
+}  // namespace
+
+int main() {
+    std::cout << "======= dumpSMT2 re-parse tests =======\n";
+    test_datatype_dump();
+    test_declaration_order_is_stable();
+    test_declare_sort_and_functions();
+    test_logic_line_is_parsable();
+    std::cout << "All dumpSMT2 re-parse tests passed.\n";
+    return 0;
+}


### PR DESCRIPTION
Found while auditing test coverage for #44 / #45 / #46, and independent of all three — cut from `main`.

`dumpSMT2()` produced scripts our own parser rejects. Three separate causes, all on the declaration side; the assertion bodies were already fine.

## 1. Datatypes were not dumped as datatypes — severe

`defineDatatypeConstructors` registers each constructor, selector and tester as an ordinary function, so a datatype query dumped as:

```smt2
(set-logic UNKNOWN_LOGIC)
(declare-fun l () L)          ← L is never declared anywhere
(declare-fun nil () L)
(declare-fun is-nil (L) Bool)
(declare-fun cons (Int L) L)
(declare-fun hd (L) Int)
...
```

Re-parsing died on the undeclared sort: `error: Unknown or unexpected symbol "L"`. **No datatype benchmark could survive a dump/re-parse cycle.**

Now reconstructed from the sort's stored constructor list:

```smt2
(declare-datatypes ((L 0)) (((nil) (cons (hd Int) (tl L)))))
(declare-fun l () L)
```

The constructor/selector/tester functions are skipped when emitting `declare-fun`s — the datatype declaration already introduces them, so emitting both would make the dump reject *itself* as a redeclaration. The test pins that too, not just the presence of the `declare-datatypes` line.

## 2. Declaration order was hash order — medium

Declarations were emitted by iterating `unordered_map`, so the order bore no relation to the input and `dump → parse → dump` did not converge: a script declaring `x` then `i` came back as `i` then `x` on the second pass.

`SymbolManager` now records first-registration order for sorts, variables and temp variables — the way `function_names_` already did for functions — and `getVariables()` / `getDeclaredVariables()` / `dumpSMT2` walk that order. Names dropped from the underlying map are skipped via the map lookup, so removal needs no extra bookkeeping.

## 3. The logic line was not a logic — severe, and universal

An input without `(set-logic ...)` leaves the logic at the placeholder `UNKNOWN_LOGIC`, which the dump emitted verbatim. That is not a logic name any parser accepts, ours included — so **every** dump of such an input was unreadable, datatypes or not. This one only surfaced after fixing #1, because #1 failed first.

Now emits `ALL`, which is what "no logic was stated" means for a dump. An explicitly stated logic is passed through unchanged.

## Testing

New `test/regression/test_dump_reparse.cpp`. The core helper dumps, re-parses the dump, and dumps again, requiring a **fixed point** — the property that was actually broken, and one that asserting on a single dump would not catch.

Covered: a datatype, a multi-constructor datatype with selectors, an uninterpreted sort with a function over it, a `define-fun`, an explicit `set-logic`, and a script with none. Plus: declarations follow input order, and the same input dumps byte-identically from two separate parsers.

Failure-before / pass-after was verified rather than assumed — built against the pre-fix code the test fails on the first case with exactly the symptoms above.

The cases deliberately avoid operators whose printing is fixed in #44 (`bv2int`, tuples, the tester spelling), so this file stands on its own on `main`.

| configuration | result |
|---|---|
| Release | **37/37** |
| Debug | **37/37** |

## Relationship to the other PRs

No file overlap with #45 or #46. Touches `src/frontend/base_parser.cpp` as #44 does, but in different functions (`dumpSMT2` / `getVariables` vs. the parse paths), so no conflict is expected.

Worth noting the two interact usefully: #44 makes the *terms* re-parsable (`bv2int` no longer prints as `UNKNOWN_KIND`, the tester uses the standard `((_ is C) x)` spelling), this makes the *declarations* re-parsable. Either alone leaves dump/re-parse broken for some input; together the cycle closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)