### PR TITLE
feat(dump): round-trip :named annotations, and scope them correctly

### DIFF
--- a/include/somtparser/frontend/parser.h
+++ b/include/somtparser/frontend/parser.h
@@ -4238,6 +4238,8 @@ namespace SOMTParser{
         void		err_open_file(const std::string) const;
 
         void 		warn_cmd_nsup(const std::string nm, const size_t ln) const;
+        /** Reports what a `:named` annotation displaced; silent when it displaced nothing. */
+        void        warn_named_displaced(const NameAssertionOutcome& outcome, const std::string& name, const size_t ln) const;
 
         // collect atoms
         void        collectAtoms(std::shared_ptr<DAGNode> expr, std::unordered_set<std::shared_ptr<DAGNode>>& atoms, std::unordered_set<std::shared_ptr<DAGNode>>& visited);

--- a/include/somtparser/frontend/parser_context.h
+++ b/include/somtparser/frontend/parser_context.h
@@ -57,8 +57,24 @@ struct ScopeFrame {
     std::vector<std::string> added_funs;
     std::vector<std::string> added_sorts;
     std::vector<std::string> added_named_assertion_keys;
+    // Bindings this scope displaced. Naming an assertion drops any earlier name
+    // for the same node, and may steal a name from another node; popping has to
+    // put the outer binding back or it would be lost with no way to recover it.
+    std::vector<std::pair<std::string, std::shared_ptr<DAGNode>>> replaced_named_assertions;
     std::vector<std::string> added_assertion_group_keys;
     std::vector<std::string> added_soft_assertion_group_keys;
+};
+
+/**
+ * What naming an assertion displaced. Both flags can be set at once, e.g. when
+ * the assertion already had a name and the new name belonged to another one.
+ */
+struct NameAssertionOutcome {
+    /** The assertion already carried a name; previous_name has been dropped. */
+    bool assertion_was_named = false;
+    std::string previous_name;
+    /** The name already referred to a different assertion, which loses it. */
+    bool name_was_reused = false;
 };
 
 /**
@@ -82,6 +98,11 @@ public:
 public:
     std::vector<std::shared_ptr<DAGNode>> assertions;
     std::unordered_map<std::string, std::unordered_set<size_t>> assertion_groups;
+    // Kept a bijection by nameAssertion(): every name refers to one assertion
+    // and every assertion carries at most one name. Nodes are hash-consed, so
+    // two textually distinct `:named` annotations on equal terms land on the
+    // same node; without the bijection dumpSMT2 could not tell which name to
+    // print for it. Register through nameAssertion(), not by writing here.
     std::unordered_map<std::string, std::shared_ptr<DAGNode>> named_assertions;
     std::vector<std::vector<std::shared_ptr<DAGNode>>> assumptions;
     std::vector<std::shared_ptr<DAGNode>> soft_assertions;
@@ -107,6 +128,16 @@ public:
     void resetAssertions();
     void resetAll();
 
+    // --- Named assertions (:named, for unsat cores and for dumpSMT2) ---
+    /**
+     * Bind `name` to `node`, dropping whatever the bijection forces out, and
+     * record the change in the current scope. The caller reports the returned
+     * displacements as warnings; this class does no I/O.
+     */
+    NameAssertionOutcome nameAssertion(const std::string& name, const std::shared_ptr<DAGNode>& node);
+    /** The name bound to `node`, or nullptr. Valid until named_assertions changes. */
+    const std::string* getAssertionName(const std::shared_ptr<DAGNode>& node) const;
+
     // Helpers to record additions in the current scope (no-op if no scope is active)
     void registerVarInScope(const std::string& name);
     void registerFunInScope(const std::string& name);
@@ -114,6 +145,12 @@ public:
     void registerNamedAssertionInScope(const std::string& name);
     void registerAssertionGroupInScope(const std::string& name);
     void registerSoftAssertionGroupInScope(const std::string& name);
+
+private:
+    // Inverse of named_assertions. Keeps "does this assertion already have a
+    // name?" O(1) on the parse path and lets dumpSMT2 look a name up per
+    // assertion. The shared_ptr key keeps the node alive alongside the forward map.
+    std::unordered_map<std::shared_ptr<DAGNode>, std::string> assertion_names_;
 };
 
 } // namespace SOMTParser

--- a/src/frontend/base_parser.cpp
+++ b/src/frontend/base_parser.cpp
@@ -3579,6 +3579,13 @@ namespace SOMTParser{
 		// Hash-consing can put one named node in `assertions` more than once --
 		// (assert (! p :named n)) (assert p) -- and repeating the name would be a
 		// duplicate declaration on re-parse, so only the first occurrence carries it.
+		//
+		// NOT SUPPORTED: a name on a nested subterm, e.g.
+		// (assert (and (! p :named n) q)).  SMT-LIB allows :named on any term,
+		// and the parser records such a name so getNamedAssertions() can find
+		// it, but this loop annotates whole assertions, so the name is dropped
+		// from the dump.  Emitting it would mean re-inserting the annotation at
+		// the right position while printing the term.
 		std::unordered_set<std::string> emitted_names;
 		for(auto& constraint : context_.assertions){
 			const std::string* name = context_.getAssertionName(constraint);

--- a/src/frontend/base_parser.cpp
+++ b/src/frontend/base_parser.cpp
@@ -1068,18 +1068,22 @@ namespace SOMTParser{
 			size_t index = context_.assertions.size();
 			context_.assertions.emplace_back(assert_expr);
 			// 
-			if(grp_id == ""){
+			// (assert <expr> [:id <symbol>] [:named <symbol>]), in either order.
+			// attemptParseKeywords() consumes the keyword it reads, so the two
+			// separate attempts this replaces did not compose: the one looking
+			// for :id swallowed a trailing :named and discarded it, and the
+			// :named attempt then saw the bare name. Loop over the keywords
+			// instead, the way parseAssertSoft already does.
+			while(true){
 				KEYWORD key_ = attemptParseKeywords();
-				if(key_ == KEYWORD::KW_ID){
-					// (assert <expr> [:id <symbol>])
+				if(key_ == KEYWORD::KW_ID && grp_id == ""){
 					grp_id = getSymbol();
 				}
-			}
-			if (named_name == ""){
-				KEYWORD key_ = attemptParseKeywords();
-				if(key_ == KEYWORD::KW_NAMED){
-					// (assert <expr> (! expr :named <symbol>))
+				else if(key_ == KEYWORD::KW_NAMED && named_name == ""){
 					named_name = getSymbol();
+				}
+				else{
+					break;
 				}
 			}
 			// if grp_id is not empty, insert to assertion_groups
@@ -1093,8 +1097,8 @@ namespace SOMTParser{
 			}
 			//if named_name is not empty, insert to named_assertions
 			if (named_name != ""){
-				context_.named_assertions[named_name] = assert_expr;
-				context_.registerNamedAssertionInScope(named_name);
+				warn_named_displaced(context_.nameAssertion(named_name, assert_expr),
+				                     named_name, command_ln);
 			}
 			if(grp_id != ""){
 				context_.registerAssertionGroupInScope(grp_id);
@@ -3569,9 +3573,21 @@ namespace SOMTParser{
 			ss << dumpFuncDef(func) << std::endl;
 		}
 	}
-		// constraints
+		// constraints. A `:named` annotation is stripped during parsing and kept
+		// aside for unsat cores; dumping it back is what lets a dumped script
+		// still answer (get-unsat-core) with the names the input used.
+		// Hash-consing can put one named node in `assertions` more than once --
+		// (assert (! p :named n)) (assert p) -- and repeating the name would be a
+		// duplicate declaration on re-parse, so only the first occurrence carries it.
+		std::unordered_set<std::string> emitted_names;
 		for(auto& constraint : context_.assertions){
-			ss << "(assert " << dumpSMTLIB2(constraint) << ")" << std::endl;
+			const std::string* name = context_.getAssertionName(constraint);
+			if(name && emitted_names.insert(*name).second){
+				ss << "(assert (! " << dumpSMTLIB2(constraint) << " :named " << *name << "))" << std::endl;
+			}
+			else{
+				ss << "(assert " << dumpSMTLIB2(constraint) << ")" << std::endl;
+			}
 		}
 		ss << "(check-sat)" << std::endl;
 		ss << "(exit)" << std::endl;
@@ -3604,6 +3620,20 @@ namespace SOMTParser{
 	// command not support
 	void Parser::warn_cmd_nsup(const std::string nm, const size_t ln) const {
 		std::cout << "warning: \"" << nm << "\" command is safely ignored in line " << ln << "." << std::endl;
+	}
+
+	// An assertion carries at most one name, so a second ":named" on the same
+	// assertion -- or a name taken from another one -- drops a binding. Say so:
+	// the loss is silent otherwise and only shows up in an unsat core.
+	void Parser::warn_named_displaced(const NameAssertionOutcome& outcome, const std::string& name, const size_t ln) const {
+		if (outcome.assertion_was_named) {
+			std::cout << "warning: assertion was already named \"" << outcome.previous_name
+			          << "\" in line " << ln << "; keeping only the last name \"" << name << "\"." << std::endl;
+		}
+		if (outcome.name_was_reused) {
+			std::cout << "warning: name \"" << name << "\" was already used for another assertion in line "
+			          << ln << "; keeping only the last assertion so named." << std::endl;
+		}
 	}
 
 	ParserPtr newParser(){

--- a/src/frontend/expr_parser.cpp
+++ b/src/frontend/expr_parser.cpp
@@ -440,8 +440,10 @@ namespace SOMTParser{
                                 scanToNextSymbol();
                                 if(kw == ":named" && *bufptr
                                    && *bufptr != ':' && *bufptr != ')'){
+                                    size_t name_ln = line_number;
                                     std::string name = getSymbol();
-                                    context_.named_assertions[name] = formula;
+                                    warn_named_displaced(context_.nameAssertion(name, formula),
+                                                         name, name_ln);
                                     scanToNextSymbol();
                                 }else if(keep_annots && kw == ":pattern" && *bufptr == '('){
                                     parseLpar();

--- a/src/frontend/expr_parser.cpp
+++ b/src/frontend/expr_parser.cpp
@@ -440,6 +440,11 @@ namespace SOMTParser{
                                 scanToNextSymbol();
                                 if(kw == ":named" && *bufptr
                                    && *bufptr != ':' && *bufptr != ')'){
+                                    // `formula` is a whole assertion only when this
+                                    // (! ...) sits directly under (assert ...). A name
+                                    // on a nested subterm is recorded here and found by
+                                    // getNamedAssertions(), but dumpSMT2 annotates whole
+                                    // assertions and so drops it -- not supported for now.
                                     size_t name_ln = line_number;
                                     std::string name = getSymbol();
                                     warn_named_displaced(context_.nameAssertion(name, formula),

--- a/src/frontend/parser_context.cpp
+++ b/src/frontend/parser_context.cpp
@@ -80,9 +80,20 @@ void ParserContext::popScope(size_t n) {
             for (const auto& name : frame.added_sorts) sm->removeSort(name);
         }
 
-        // Remove added named assertions
+        // Remove added named assertions, then put back whatever they displaced.
+        // Reverse order so that when a name was displaced repeatedly the
+        // outermost binding -- recorded first -- is the one that survives.
         for (const auto& key : frame.added_named_assertion_keys) {
-            named_assertions.erase(key);
+            auto it = named_assertions.find(key);
+            if (it != named_assertions.end()) {
+                assertion_names_.erase(it->second);
+                named_assertions.erase(it);
+            }
+        }
+        for (auto it = frame.replaced_named_assertions.rbegin();
+             it != frame.replaced_named_assertions.rend(); ++it) {
+            named_assertions[it->first] = it->second;
+            assertion_names_[it->second] = it->first;
         }
 
         // Remove added assertion group indices
@@ -129,6 +140,7 @@ void ParserContext::resetAssertions() {
     assertion_groups.clear();
     soft_assertion_groups.clear();
     named_assertions.clear();
+    assertion_names_.clear();
     split_lemmas.clear();
     // Note: scope_stack_ is NOT cleared; declarations and options are kept.
 }
@@ -145,6 +157,51 @@ void ParserContext::resetAll() {
     if (auto om = getObjectiveManager()) {
         om->clear();
     }
+}
+
+// --- Named assertions ---
+
+NameAssertionOutcome ParserContext::nameAssertion(const std::string& name,
+                                                 const std::shared_ptr<DAGNode>& node) {
+    NameAssertionOutcome out;
+    if (!node) return out;
+
+    // Already bound exactly this way: nothing changes, and in particular this
+    // scope must not claim it added the binding -- popping would then delete a
+    // name that an enclosing scope owns.
+    auto existing = named_assertions.find(name);
+    if (existing != named_assertions.end() && existing->second == node) return out;
+
+    ScopeFrame* frame = scope_stack_.empty() ? nullptr : &scope_stack_.back();
+
+    // Naming an assertion that already has a name: the old name goes away, so
+    // the bijection holds and a dump has exactly one name to print for it.
+    auto old = assertion_names_.find(node);
+    if (old != assertion_names_.end() && old->second != name) {
+        out.assertion_was_named = true;
+        out.previous_name = old->second;
+        if (frame) frame->replaced_named_assertions.emplace_back(old->second, node);
+        named_assertions.erase(old->second);
+        assertion_names_.erase(old);
+    }
+
+    // Reusing a name for a different assertion: the earlier one loses it.
+    auto taken = named_assertions.find(name);
+    if (taken != named_assertions.end() && taken->second != node) {
+        out.name_was_reused = true;
+        if (frame) frame->replaced_named_assertions.emplace_back(name, taken->second);
+        assertion_names_.erase(taken->second);
+    }
+
+    named_assertions[name] = node;
+    assertion_names_[node] = name;
+    registerNamedAssertionInScope(name);
+    return out;
+}
+
+const std::string* ParserContext::getAssertionName(const std::shared_ptr<DAGNode>& node) const {
+    auto it = assertion_names_.find(node);
+    return it == assertion_names_.end() ? nullptr : &it->second;
 }
 
 // --- Scope recording helpers (no-op if no active scope) ---

--- a/test/regression/test_named_assertions.cpp
+++ b/test/regression/test_named_assertions.cpp
@@ -1,0 +1,201 @@
+// A `:named` annotation is stripped while parsing and kept aside for unsat
+// cores.  Three things were wrong with that:
+//
+//   * dumpSMT2 never emitted it, so a dumped script could no longer answer
+//     (get-unsat-core) with the names the input used;
+//   * the standard form (assert (! e :named n)) never registered the name with
+//     the push/pop scope, so the name outlived the (pop ...) that removed the
+//     assertion it belonged to;
+//   * naming the same assertion twice silently dropped one binding -- nodes are
+//     hash-consed, so `(! A :named X)` and `(! A :named Y)` name one node.
+//
+// The last one has no lossless answer: the parser now warns and keeps the last
+// name.  These tests pin the warning down as much as the result.
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "somtparser/frontend/parser.h"
+#include "test_helpers.h"
+
+using namespace SOMTParser;
+
+namespace {
+
+void fail(const std::string& what, const std::string& detail) {
+    std::cerr << "FAILED " << what << "\n" << detail;
+    std::abort();
+}
+
+void expectContains(const std::string& what, const std::string& hay, const std::string& needle) {
+    if (hay.find(needle) == std::string::npos)
+        fail(what, "expected to find\n  " + needle + "\nin\n" + hay);
+}
+
+void expectAbsent(const std::string& what, const std::string& hay, const std::string& needle) {
+    if (hay.find(needle) != std::string::npos)
+        fail(what, "did not expect\n  " + needle + "\nin\n" + hay);
+}
+
+// Parse with std::cout captured, so the warnings are testable.
+struct Parsed {
+    ParserPtr parser;
+    std::string warnings;
+};
+
+Parsed parseCapturing(const std::string& script) {
+    std::ostringstream captured;
+    std::streambuf* saved = std::cout.rdbuf(captured.rdbuf());
+    ParserPtr p = newParser();
+    try {
+        p->parseStr(script);
+    } catch (...) {
+        std::cout.rdbuf(saved);
+        throw;
+    }
+    std::cout.rdbuf(saved);
+    return {p, captured.str()};
+}
+
+// Dump, re-parse the dump, dump again; require a fixed point.  Returns it.
+std::string dumpFixedPoint(const std::string& label, const std::string& script) {
+    ParserPtr p = newParser();
+    p->parseStr(script);
+    const std::string once = p->dumpSMT2();
+
+    ParserPtr q = newParser();
+    q->parseStr(once);
+    const std::string twice = q->dumpSMT2();
+
+    if (once != twice)
+        fail(label, "dump is not a fixed point\n--- first ---\n" + once + "--- second ---\n" + twice);
+    std::cout << "  ok: " << label << "\n";
+    return once;
+}
+
+const std::string DECLS = "(set-logic ALL)\n(declare-fun A () Bool)\n(declare-fun B () Bool)\n";
+
+// ── The name has to come back out. ────────────────────────────────────────
+void test_named_survives_dump() {
+    std::cout << "-- :named round trip --\n";
+    const std::string dump = dumpFixedPoint(
+        "standard (! e :named n)",
+        DECLS + "(assert (! A :named AA))\n(assert (! (not B) :named BB))\n(assert (= A B))\n");
+
+    expectContains("name is emitted", dump, ":named AA");
+    expectContains("name is emitted", dump, ":named BB");
+    // The unnamed assertion stays unannotated.
+    expectContains("unnamed assertion stays plain", dump, "(assert (= A B))");
+
+    // And the names still resolve to the same assertions after a round trip.
+    ParserPtr q = newParser();
+    q->parseStr(dump);
+    auto named = q->getNamedAssertions();
+    VERIFY(named.size() == 2);
+    VERIFY(named.count("AA") == 1 && named.count("BB") == 1);
+    VERIFY(q->toString(named["AA"]) == "A");
+    std::cout << "  ok: names still resolve after a round trip\n";
+
+    // The non-standard trailing form the parser also accepts.
+    const std::string trailing =
+        dumpFixedPoint("trailing (assert e :named n)", DECLS + "(assert A :named AA)\n");
+    expectContains("trailing form keeps its name", trailing, ":named AA");
+}
+
+// ── One assertion, two names: warn, keep the last. ────────────────────────
+void test_assertion_named_twice() {
+    std::cout << "-- one assertion named twice --\n";
+    // Hash-consing makes both asserts the same node.
+    Parsed r = parseCapturing(DECLS + "(assert (! A :named AA))\n(assert (! A :named BB))\n");
+    expectContains("a dropped name is reported", r.warnings, "already named");
+    expectContains("the warning names the survivor", r.warnings, "BB");
+    expectContains("the warning names the casualty", r.warnings, "AA");
+
+    auto named = r.parser->getNamedAssertions();
+    VERIFY(named.size() == 1);
+    VERIFY(named.count("BB") == 1 && named.count("AA") == 0);
+    std::cout << "  ok: warned, and only the last name survives\n";
+
+    const std::string dump = r.parser->dumpSMT2();
+    expectContains("survivor is dumped", dump, ":named BB");
+    expectAbsent("dropped name is not dumped", dump, ":named AA");
+
+    // Re-naming with the *same* name is not a displacement and must not warn.
+    Parsed same = parseCapturing(DECLS + "(assert (! A :named AA))\n(assert (! A :named AA))\n");
+    expectAbsent("re-stating the same name is silent", same.warnings, "warning:");
+    VERIFY(same.parser->getNamedAssertions().size() == 1);
+    std::cout << "  ok: re-stating the same name is not a displacement\n";
+}
+
+// ── One name, two assertions: warn, keep the last. ────────────────────────
+void test_name_reused() {
+    std::cout << "-- one name for two assertions --\n";
+    Parsed r = parseCapturing(DECLS + "(assert (! A :named N))\n(assert (! B :named N))\n");
+    expectContains("a stolen name is reported", r.warnings, "already used for another assertion");
+
+    auto named = r.parser->getNamedAssertions();
+    VERIFY(named.size() == 1);
+    VERIFY(r.parser->toString(named["N"]) == "B");
+    std::cout << "  ok: warned, and the name refers to the last assertion\n";
+
+    // The assertion that lost the name must dump plain, not with a stale one.
+    const std::string dump = r.parser->dumpSMT2();
+    expectContains("survivor keeps the name", dump, "(assert (! B :named N))");
+    expectContains("the other dumps plain", dump, "(assert A)");
+}
+
+// ── The same node asserted twice carries the name once. ───────────────────
+void test_repeated_assertion_names_once() {
+    std::cout << "-- a named node asserted twice --\n";
+    // Emitting ":named AA" on both would be a duplicate name on re-parse.
+    const std::string dump =
+        dumpFixedPoint("named node asserted twice", DECLS + "(assert (! A :named AA))\n(assert A)\n");
+    size_t first = dump.find(":named AA");
+    VERIFY(first != std::string::npos);
+    VERIFY(dump.find(":named AA", first + 1) == std::string::npos);
+    std::cout << "  ok: the name is emitted exactly once\n";
+}
+
+// ── Names live and die with their scope. ──────────────────────────────────
+void test_scope() {
+    std::cout << "-- push/pop --\n";
+    ParserPtr p = newParser();
+    p->parseStr(DECLS + "(push 1)\n(assert (! A :named AA))\n(pop 1)\n");
+    VERIFY(p->getAssertions().empty());
+    // The name used to outlive the assertion it belonged to.
+    VERIFY(p->getNamedAssertions().empty());
+    std::cout << "  ok: a popped assertion takes its name with it\n";
+
+    // A name displaced inside a scope comes back when the scope goes away.
+    ParserPtr q = newParser();
+    q->parseStr(DECLS + "(assert (! A :named AA))\n(push 1)\n(assert (! A :named BB))\n(pop 1)\n");
+    auto named = q->getNamedAssertions();
+    if (!(named.size() == 1 && named.count("AA") == 1)) {
+        std::string got;
+        for (const auto& kv : named) got += "  " + kv.first + "\n";
+        fail("displaced name is not restored on pop", "expected only AA, got:\n" + got);
+    }
+    std::cout << "  ok: a name displaced inside a scope is restored on pop\n";
+
+    // Same for a name stolen by another assertion inside the scope.
+    ParserPtr s = newParser();
+    s->parseStr(DECLS + "(assert (! A :named N))\n(push 1)\n(assert (! B :named N))\n(pop 1)\n");
+    auto restored = s->getNamedAssertions();
+    VERIFY(restored.size() == 1 && restored.count("N") == 1);
+    VERIFY(s->toString(restored["N"]) == "A");
+    std::cout << "  ok: a stolen name goes back to its owner on pop\n";
+}
+
+}  // namespace
+
+int main() {
+    std::cout << "======= named assertion tests =======\n";
+    test_named_survives_dump();
+    test_assertion_named_twice();
+    test_name_reused();
+    test_repeated_assertion_names_once();
+    test_scope();
+    std::cout << "All named assertion tests passed.\n";
+    return 0;
+}

--- a/test/regression/test_named_assertions.cpp
+++ b/test/regression/test_named_assertions.cpp
@@ -11,6 +11,10 @@
 //
 // The last one has no lossless answer: the parser now warns and keeps the last
 // name.  These tests pin the warning down as much as the result.
+//
+// Out of scope: a name on a nested subterm, (assert (and (! p :named n) q)).
+// It is parsed and recorded, but dumpSMT2 annotates whole assertions, so the
+// name does not survive a dump -- not supported for now.
 
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
`:named` was parsed, stored for unsat cores, and then dropped on the floor by `dumpSMT2()`. A dumped script could no longer answer `(get-unsat-core)` with the names its input used. Fixing that surfaced three more defects in the same path.

## 1. The name never came back out

```smt2
(assert (! A :named AA))
```
dumped as `(assert A)`. Now it dumps as itself.

## 2. Names outlived their scope

`(assert (! e :named n))` is handled in `expr_parser.cpp`, which wrote `named_assertions` directly and never called `registerNamedAssertionInScope`. Only the trailing form `(assert e :named n)` did. So:

```smt2
(push 1) (assert (! A :named AA)) (pop 1)
```
left `assertions` empty but `named_assertions` still holding `AA`. Verified against `main` before the fix.

## 3. The trailing form recorded no name at all

`(assert A :named AA)` produced **zero** named assertions — on `main` too.

`attemptParseKeywords()` consumes the keyword it reads. The code ran two independent attempts, the first accepting only `:id`; it consumed the trailing `:named` and discarded it, and the second attempt then saw the bare symbol `AA`. Replaced with a loop over keywords, which is what `parseAssertSoft` already does.

## 4. Hash-consing makes `name → node` non-injective

`named_assertions` is `name → node`, and nodes are hash-consed, so in

```smt2
(assert (! A :named AA))
(assert (! A :named BB))
```

both `A` are the *same* `shared_ptr`. The map holds `{AA: A, BB: A}` and a dump has no way to pick a name for that node.

Two ways out: carry the assert index so both names survive, or make the map a bijection. This takes the second — `named_assertions` is public API (`getNamedAssertions()`), and "one assertion, at most one name" is an invariant callers can rely on, whereas an index-keyed variant changes what the getter means.

So there is no lossless answer, and per the agreed semantics the parser **warns and keeps the last name**:

```
warning: assertion was already named "AA" in line 4; keeping only the last name "BB".
warning: name "N" was already used for another assertion in line 4; keeping only the last assertion so named.
```

Re-stating the *same* name for the same assertion is not a displacement and stays silent.

## How it is held together

Both writers now go through `ParserContext::nameAssertion()`, which is the only place the invariant lives. It maintains the inverse map (`assertion_names_`, so the parse path and the dump are both O(1) rather than scanning), records displaced bindings in the active `ScopeFrame`, and returns what it dropped for the caller to warn about — `ParserContext` still does no I/O.

`popScope` restores displacements in reverse, so a name displaced or stolen inside a scope goes back to its owner on `(pop ...)` instead of vanishing. Without that, routing through `nameAssertion` would have *introduced* a leak: dropping the old name and then popping the new one would leave the assertion nameless.

`dumpSMT2` names only the first occurrence when one node is asserted twice — `(assert (! p :named n))` followed by `(assert p)` is one hash-consed node in `assertions` twice, and repeating the name would be a duplicate on re-parse.

## Tests

`test/regression/test_named_assertions.cpp`, built on dump → re-parse → dump fixed point:

- both annotation forms round-trip, and the names still resolve to the same assertions afterwards
- one assertion named twice → warning, last name wins, dropped name absent from the dump
- one name for two assertions → warning, name follows the last assertion, the other dumps plain
- re-stating the same name → silent, no displacement
- a node asserted twice carries the name exactly once
- `push`/`pop`: a popped assertion takes its name with it; a name displaced *or* stolen inside a scope is restored on pop

Warnings are asserted by capturing `std::cout`'s `rdbuf` — the semantics agreed here are as much the warning as the result, so both are pinned.

## Verification

- Debug **40/40**, Release **40/40**
- `test_somtparser_exe -r test/instances` — 21/21, no regression from the reworked keyword loop (the highest-risk edit here)
- New test compiled against the pre-fix headers *and* pre-fix library: fails on the first `:named AA` assertion. Header and library from the same commit — mixing them would have changed `ParserContext`'s layout and tested UB rather than behaviour.

## Not covered

`:named` on a nested subterm (`(assert (and (! p :named n) q))`) is still parsed and recorded but not dumped, since the dump emits names per assertion. Pre-existing, and rarer than the assert-level case; say the word if it should be in scope.
