### PR TITLE
Fix four silent rewrites: a legal input accepted, altered, and reported as success

### DIFF
--- a/include/somtparser/ir/number.h
+++ b/include/somtparser/ir/number.h
@@ -71,7 +71,24 @@ namespace SOMTParser {
             HighPrecisionInteger operator*(const HighPrecisionInteger& other) const;
             HighPrecisionInteger operator/(const HighPrecisionInteger& other) const;
             HighPrecisionInteger operator%(const HighPrecisionInteger& other) const;
-            HighPrecisionInteger floorDiv(const HighPrecisionInteger& other) const; // SMT-LIB div semantics (floor towards -inf)
+            // Three integer division conventions, kept apart on purpose. They
+            // agree when both operands are positive and disagree otherwise, and
+            // every language this project reads picks one:
+            //
+            //     m    n  | operator/ (trunc) | floorDiv | euclideanDiv
+            //    -7    2  |       -3          |    -4    |     -4
+            //    -7   -2  |        3          |     3    |      4
+            //     7   -2  |       -3          |    -4    |     -3
+            //
+            // euclideanDiv/euclideanMod are what SMT-LIB's Ints theory defines:
+            // they are the unique pair with m = n*q + r and 0 <= r < |n|.
+            // floorDiv is NOT that pair -- it agrees only for positive n -- and
+            // a comment here used to claim it was, which is how NT_DIV_INT and
+            // NT_MOD ended up disagreeing with each other (see
+            // src/frontend/simp_parser.cpp).
+            HighPrecisionInteger floorDiv(const HighPrecisionInteger& other) const;   // towards -inf
+            HighPrecisionInteger euclideanDiv(const HighPrecisionInteger& other) const;
+            HighPrecisionInteger euclideanMod(const HighPrecisionInteger& other) const;
             HighPrecisionInteger& operator+=(const HighPrecisionInteger& other);
             HighPrecisionInteger& operator-=(const HighPrecisionInteger& other);
             HighPrecisionInteger& operator*=(const HighPrecisionInteger& other);

--- a/src/frontend/base_parser.cpp
+++ b/src/frontend/base_parser.cpp
@@ -2664,7 +2664,17 @@ namespace SOMTParser{
 	// (quantifier ((<identifier> <sort>)+） <expr>)
 	std::shared_ptr<DAGNode> Parser::mkQuantVar(const std::string& name, std::shared_ptr<Sort> sort){
 		std::shared_ptr<DAGNode> var = getSymbolManager()->getQuantVar(name);
-		if(var) return var;
+		// The SORT has to match, not only the name. Reusing a binding of the
+		// same name at a different sort is how
+		//   (forall ((x Int)) (and (P x) (forall ((x (_ BitVec 8))) (Q x))))
+		// came back as
+		//   (forall ((x Int)) (and (P x) (forall ((x Int))          (Q x))))
+		// -- the inner binder silently took the outer one's sort, so Q, which
+		// is declared over (_ BitVec 8), was applied to an Int. The script
+		// parsed, printed and reported success. Shadowing is legal SMT-LIB, so
+		// this is a well-formed input being silently changed into a different
+		// problem.
+		if(var && var->getSort() && sort && var->getSort()->isEqTo(sort)) return var;
 		var = getNodeManager()->createNode(sort, NODE_KIND::NT_QUANT_VAR, name);
 		getSymbolManager()->registerQuantVar(name, var);
 		return var;
@@ -2675,13 +2685,20 @@ namespace SOMTParser{
 		parseLpar();
 		std::vector<std::shared_ptr<DAGNode>> params;
 		std::vector<std::string> quant_var_names;
+		// The bindings this quantifier shadows, so leaving its scope RESTORES
+		// them. popQuantScope erases by name, which is right when nothing was
+		// shadowed and wrong when something was: the outer binder would vanish
+		// and its remaining occurrences would resolve as free symbols.
+		std::vector<std::pair<std::string, std::shared_ptr<DAGNode>>> shadowed;
 		while (*bufptr != ')') {
 			// (quantifier ((<identifier> <sort>)+） <expr>)
 			//              ^
 			parseLpar();
 			std::string var_name = getSymbol();
 			std::shared_ptr<Sort> var_sort = parseSort();
+			std::shared_ptr<DAGNode> outer = getSymbolManager()->getQuantVar(var_name);
 			std::shared_ptr<DAGNode> var = mkQuantVar(var_name, var_sort);
+			if(outer && outer != var) shadowed.emplace_back(var_name, outer);
 			params.emplace_back(var);
 			quant_var_names.emplace_back(var_name);
 			parseRpar();
@@ -2702,6 +2719,9 @@ namespace SOMTParser{
 			condAssert(false, "Invalid quantifier");
 		}
 		getSymbolManager()->popQuantScope(quant_var_names);
+		for(auto it = shadowed.rbegin(); it != shadowed.rend(); ++it){
+			getSymbolManager()->registerQuantVar(it->first, it->second);
+		}
 		return res;
 	}
 

--- a/src/frontend/op_parser.cpp
+++ b/src/frontend/op_parser.cpp
@@ -1246,12 +1246,25 @@ namespace SOMTParser{
                 }
             }
             if(isZero(params[i])){
-                if(getOptions()->isIntTheory()){
-                    return mkConstInt(0);
-                }
-                else if(getOptions()->isRealTheory()){
+                // Zero ANNIHILATES a product, and which sort the zero comes
+                // back as follows the operands -- not the active logic.
+                //
+                // This used to ask getOptions() and had no fallback, so when
+                // the logic named neither theory control fell out of the `if`
+                // and the zero was added to neither new_params nor the result:
+                // it vanished, and (* x 0) came back as x. The default logic
+                // is "ALL", whose string contains neither "I" nor "R", so the
+                // condition that triggered it was not exotic -- it was every
+                // model built before a set-logic, which is every model built
+                // through the API.
+                //
+                // Deciding by logic was also wrong where it did fire: under a
+                // mixed logic such as AUFLIRA, isRealTheory() holds and an
+                // Int-sorted product returned a Real zero.
+                if(sort != nullptr && sort->isReal()){
                     return mkConstReal(0.0);
                 }
+                return mkConstInt(0);
             }
             else if(isOne(params[i])){
                 continue;

--- a/src/frontend/op_parser.cpp
+++ b/src/frontend/op_parser.cpp
@@ -95,7 +95,17 @@ namespace SOMTParser{
     }
 
     bool canExempt(std::shared_ptr<Sort> l, std::shared_ptr<Sort> r){
-        if((l->isInt() || l->isReal()) && (r->isInt() || r->isReal())){
+        // IntOrReal has to be in this list. It is the sort a numeric LITERAL
+        // carries -- `2` is IntOrReal, not Int -- so leaving it out meant
+        // `(/ x 2)` was rejected as a type mismatch while `(/ x y)` on two
+        // declared Reals passed. getSort(), twenty lines below, already asks
+        // isIntOrReal() for exactly this reason; this function did not, and the
+        // divergence showed up only where a literal met an operator that wants
+        // Reals.
+        const auto numeric = [](const std::shared_ptr<Sort>& s){
+            return s->isInt() || s->isReal() || s->isIntOrReal();
+        };
+        if(numeric(l) && numeric(r)){
             return true;
         }
         // Special handling for root-obj and root-of-with-interval nodes

--- a/src/frontend/simp_parser.cpp
+++ b/src/frontend/simp_parser.cpp
@@ -955,8 +955,21 @@ namespace SOMTParser{
                     return mkUnknown();
                 }
                 if(l->isCInt() && r->isCInt()){
-                    // SMT-LIB div uses floor semantics (towards -inf), not C++ truncation
-                    return mkConstInt(toInt(l).floorDiv(toInt(r)));
+                    // SMT-LIB's Ints theory defines div and mod together, as the
+                    // unique q, r with m = n*q + r and 0 <= r < |n| -- Euclidean,
+                    // not floor and not C++ truncation. This used to call
+                    // floorDiv while NT_MOD below used C++ '%', which agree only
+                    // when both operands are positive: (div -7 2) folded to -4
+                    // and (mod -7 2) to -1, so 2*(-4) + (-1) = -9, not -7. The
+                    // defining identity was broken by the folding itself.
+                    if(toInt(r) == Integer(0)){
+                        // Division by zero is *total* in SMT-LIB and its value is
+                        // unconstrained, so there is no constant to fold to.
+                        // Leaving the term symbolic is the faithful action;
+                        // throwing would reject a script a solver accepts.
+                        return mkUnknown();
+                    }
+                    return mkConstInt(toInt(l).euclideanDiv(toInt(r)));
                 }
                 else if((l->isCReal() && r->isCReal()) || (l->isCInt() && r->isCReal()) || (l->isCReal() && r->isCInt()) || (l->isCInt() && r->isCInt())){
                     if(getEvaluateUseFloating()){
@@ -996,7 +1009,14 @@ namespace SOMTParser{
                     return mkUnknown();
                 }
                 if(l->isCInt() && r->isCInt()){
-                    return mkConstInt(toInt(l) % toInt(r));
+                    // Euclidean, to match NT_DIV_INT above. C++ '%' truncates and
+                    // takes the sign of the dividend, so it returned negative
+                    // remainders -- violating SMT-LIB's 0 <= (mod m n) < |n| in
+                    // every case with a negative dividend.
+                    if(toInt(r) == Integer(0)){
+                        return mkUnknown();     // see NT_DIV_INT
+                    }
+                    return mkConstInt(toInt(l).euclideanMod(toInt(r)));
                 }
                 return mkUnknown();
             }

--- a/src/ir/number.cpp
+++ b/src/ir/number.cpp
@@ -815,6 +815,39 @@ HighPrecisionInteger HighPrecisionInteger::floorDiv(const HighPrecisionInteger& 
     return HighPrecisionInteger(q.get_str());
 }
 
+// Euclidean division, as SMT-LIB's Ints theory defines div and mod: the unique
+// q, r with m = n*q + r and 0 <= r < |n|.
+//
+// GMP has no Euclidean rounding mode, but it falls out of the two it does have:
+// the remainder of a floor division is non-negative exactly when the divisor is
+// positive, and the remainder of a ceiling division is non-negative exactly
+// when the divisor is negative. So pick by the sign of the divisor.
+HighPrecisionInteger HighPrecisionInteger::euclideanDiv(const HighPrecisionInteger& other) const {
+    if (other.value == 0) {
+        throw std::domain_error("Division by zero");
+    }
+    mpz_class q;
+    if (other.value > 0) {
+        mpz_fdiv_q(q.get_mpz_t(), value.get_mpz_t(), other.value.get_mpz_t());
+    } else {
+        mpz_cdiv_q(q.get_mpz_t(), value.get_mpz_t(), other.value.get_mpz_t());
+    }
+    return HighPrecisionInteger(q.get_str());
+}
+
+HighPrecisionInteger HighPrecisionInteger::euclideanMod(const HighPrecisionInteger& other) const {
+    if (other.value == 0) {
+        throw std::domain_error("Modulo by zero");
+    }
+    mpz_class r;
+    if (other.value > 0) {
+        mpz_fdiv_r(r.get_mpz_t(), value.get_mpz_t(), other.value.get_mpz_t());
+    } else {
+        mpz_cdiv_r(r.get_mpz_t(), value.get_mpz_t(), other.value.get_mpz_t());
+    }
+    return HighPrecisionInteger(r.get_str());
+}
+
 HighPrecisionInteger& HighPrecisionInteger::operator+=(const HighPrecisionInteger& other) {
     value += other.value;
     return *this;

--- a/test/regression/test_int_div_mod_semantics.cpp
+++ b/test/regression/test_int_div_mod_semantics.cpp
@@ -1,0 +1,205 @@
+// (div m n) and (mod m n) must satisfy SMT-LIB's definition of them.
+//
+// The SMT-LIB Ints theory does not define div and mod separately. It defines
+// them *together*, as the unique pair satisfying
+//
+//     (1)  m = n * (div m n) + (mod m n)
+//     (2)  0 <= (mod m n) < |n|
+//
+// for n != 0. That is Euclidean division. It is not C++ truncation, and it is
+// not floor division either -- all three agree when both operands are positive
+// and disagree otherwise.
+//
+// Constant folding got this wrong in a way no per-operator test could catch.
+// NT_DIV_INT had been corrected to floor semantics, with a comment saying so;
+// NT_MOD, thirty lines below, still used C++ '%'. Each looked defensible alone.
+// Together they broke the identity that defines both:
+//
+//     (div -7 2) folded to -4 and (mod -7 2) to -1,
+//     so n*q + r = 2*(-4) + (-1) = -9, not -7.
+//
+// So this file does not assert a table of expected values -- a table is just
+// somebody's opinion written twice. It asserts the two laws, over a grid of
+// operands including every sign combination, and separately pins the handful of
+// values that distinguish the three conventions so a future "fix" toward the
+// wrong one fails loudly rather than quietly satisfying the laws in a different
+// way. (Laws (1) and (2) together are enough to force uniqueness, but the
+// witnesses make the failure message name the convention that was chosen.)
+//
+// Evaluation shares this path: eval_parser routes NT_MOD and NT_DIV_INT through
+// mkOper, which runs simp_oper. Fixing the folding fixes both, and the third
+// block below checks that it really is one path and not two.
+
+#include "somtparser/frontend/parser.h"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "test_helpers.h"
+
+using namespace SOMTParser;
+
+namespace {
+
+/** SMT-LIB integer literals have no unary minus, so a negative constant is the
+ *  term (- k). Building the string rather than the node keeps this test honest:
+ *  it goes through the same parse path a real script does. */
+std::string lit(long long v) {
+    return v < 0 ? "(- " + std::to_string(-v) + ")" : std::to_string(v);
+}
+
+/** Value of a folded integer term, or false if it did not fold to a constant. */
+bool constantValue(const std::shared_ptr<Parser>& p, const std::string& term,
+                   long long& out) {
+    auto n = p->mkExpr(term);
+    if (!n) { return false; }
+    const std::string s = p->toString(n);
+    try {
+        if (s.rfind("(- ", 0) == 0) {
+            out = -std::stoll(s.substr(3, s.size() - 4));
+        } else {
+            out = std::stoll(s);
+        }
+    } catch (const std::exception&) {
+        return false;        // not a numeral: the term stayed symbolic
+    }
+    return true;
+}
+
+struct Failure {
+    std::string what;
+};
+
+} // namespace
+
+int main() {
+    std::cout << "======= integer div/mod follow SMT-LIB =======\n";
+
+    auto p = std::make_shared<Parser>();
+    std::vector<Failure> failures;
+
+    // The grid covers both signs of both operands, |m| < |n| and |m| > |n|,
+    // exact and inexact division, and zero dividends.
+    const std::vector<long long> operands = {-13, -7, -6, -2, -1, 0, 1, 2, 6, 7, 13};
+    std::size_t checked = 0;
+
+    for (long long m : operands) {
+        for (long long n : operands) {
+            if (n == 0) { continue; }        // covered separately below
+
+            long long q = 0, r = 0;
+            const std::string dterm = "(div " + lit(m) + " " + lit(n) + ")";
+            const std::string mterm = "(mod " + lit(m) + " " + lit(n) + ")";
+
+            if (!constantValue(p, dterm, q)) {
+                failures.push_back({dterm + " did not fold to a constant"});
+                continue;
+            }
+            if (!constantValue(p, mterm, r)) {
+                failures.push_back({mterm + " did not fold to a constant"});
+                continue;
+            }
+            ++checked;
+
+            // (1) the defining identity
+            if (n * q + r != m) {
+                failures.push_back({
+                    "identity broken for m=" + std::to_string(m) +
+                    " n=" + std::to_string(n) + ": div=" + std::to_string(q) +
+                    " mod=" + std::to_string(r) + " gives n*div+mod=" +
+                    std::to_string(n * q + r) + ", not " + std::to_string(m)});
+            }
+            // (2) the remainder is non-negative and smaller than |n|
+            const long long abs_n = n < 0 ? -n : n;
+            if (r < 0 || r >= abs_n) {
+                failures.push_back({
+                    "remainder out of range for m=" + std::to_string(m) +
+                    " n=" + std::to_string(n) + ": mod=" + std::to_string(r) +
+                    ", must satisfy 0 <= mod < " + std::to_string(abs_n)});
+            }
+        }
+    }
+
+    // The witnesses. Each row is a case where Euclidean, floor and C++
+    // truncation give three different answers, or where two of them agree and
+    // the third does not -- so a regression toward either wrong convention
+    // names itself instead of merely failing an abstract law.
+    struct Witness { long long m, n, div, mod; const char* note; };
+    const std::vector<Witness> witnesses = {
+        {-7,  2, -4,  1, "trunc would give div=-3; C++ '%' would give mod=-1"},
+        {-7, -2,  4,  1, "floor would give div=3; C++ '%' would give mod=-1"},
+        { 7, -2, -3,  1, "floor would give div=-4"},
+        {-1,  3, -1,  2, "trunc would give div=0, mod=-1"},
+        {-6,  3, -2,  0, "exact division: all three conventions agree"},
+        { 7,  2,  3,  1, "both positive: all three conventions agree"},
+    };
+    for (const auto& w : witnesses) {
+        long long q = 0, r = 0;
+        VERIFY(constantValue(p, "(div " + lit(w.m) + " " + lit(w.n) + ")", q));
+        VERIFY(constantValue(p, "(mod " + lit(w.m) + " " + lit(w.n) + ")", r));
+        if (q != w.div || r != w.mod) {
+            failures.push_back({
+                "witness m=" + std::to_string(w.m) + " n=" + std::to_string(w.n) +
+                ": expected div=" + std::to_string(w.div) +
+                " mod=" + std::to_string(w.mod) +
+                ", got div=" + std::to_string(q) + " mod=" + std::to_string(r) +
+                "  [" + w.note + "]"});
+        }
+    }
+
+    // Division by zero is total in SMT-LIB and its value is unconstrained, so
+    // there is no constant to fold to and the term must stay symbolic. Folding
+    // it to anything would invent a value; refusing the script -- which is what
+    // this used to do, by letting a domain_error escape -- rejects a script a
+    // solver accepts.
+    for (const std::string& t : {"(div 7 0)", "(mod 7 0)",
+                                 "(div (- 7) 0)", "(mod (- 7) 0)", "(div 0 0)"}) {
+        long long ignored = 0;
+        bool folded = true;
+        bool threw = false;
+        try {
+            folded = constantValue(p, t, ignored);
+        } catch (...) {
+            threw = true;
+        }
+        if (threw) {
+            failures.push_back({t + " threw; it must stay symbolic"});
+        } else if (folded) {
+            failures.push_back({t + " folded to a constant; its value is "
+                                    "unconstrained and must stay symbolic"});
+        }
+    }
+
+    // Model evaluation must agree with folding. They are supposed to be one
+    // path -- eval_parser sends NT_MOD and NT_DIV_INT through mkOper, which
+    // runs simp_oper -- and a divergence here would mean the fix landed on only
+    // one of them, which is exactly the shape of the original defect.
+    {
+        auto q = std::make_shared<Parser>();
+        VERIFY(q->parseStr("(declare-fun x () Int)\n(declare-fun y () Int)\n"
+                           "(assert (= x (div (- 7) 2)))\n"
+                           "(assert (= y (mod (- 7) 2)))\n"));
+        long long dv = 0, mv = 0;
+        VERIFY(constantValue(q, "(div (- 7) 2)", dv));
+        VERIFY(constantValue(q, "(mod (- 7) 2)", mv));
+        if (dv != -4 || mv != 1) {
+            failures.push_back({"a parsed script folds div/mod differently from "
+                                "a directly built term"});
+        }
+    }
+
+    for (const auto& f : failures) {
+        std::cerr << "  FAIL " << f.what << "\n";
+    }
+    std::cout << checked << " operand pair(s) checked against both laws, "
+              << witnesses.size() << " witness(es), " << failures.size()
+              << " failure(s)\n";
+    VERIFY(failures.empty());
+    // A grid that silently stopped producing constants would reach here with no
+    // failures; require the laws to have actually been exercised.
+    VERIFY(checked >= 90);
+
+    std::cout << "div and mod satisfy m = n*div + mod with 0 <= mod < |n|.\n";
+    return 0;
+}

--- a/test/regression/test_int_real_literal.cpp
+++ b/test/regression/test_int_real_literal.cpp
@@ -1,0 +1,103 @@
+// A numeric literal's sort is IntOrReal, and it must be exempt from the
+// int/real type check.
+//
+// canExempt lists the sorts that may mix under the int/real exemption and
+// listed only Int and Real. A literal carries neither: `2` has sort IntOrReal.
+// So `(/ x 2)` on an Int variable was rejected as "Type mismatch in div" while
+// `(/ x y)` on two declared Reals passed -- the exemption held everywhere
+// except where a literal met an operator that wants Reals, which is most places
+// anyone would write one.
+//
+// getSort(), twenty lines below canExempt in the same file, already asked
+// isIntOrReal() for exactly this reason. The two disagreed.
+//
+// The failure was also reported badly, and that is worth its own case below:
+// err_all THROWS ParseErrorException rather than returning an error node, so a
+// well-formed term rejected here does not come back as `isErr()` -- it unwinds
+// out of the builder. A caller that expected a node got an exception instead.
+
+#include "somtparser/parser.h"
+
+#include <iostream>
+#include <string>
+
+#include "test_helpers.h"
+
+using namespace SOMTParser;
+
+namespace {
+
+bool has(const std::string& hay, const std::string& needle) {
+    return hay.find(needle) != std::string::npos;
+}
+
+/** True when building @p f raises the parser's type error. err_all throws, so
+ *  a rejection cannot be observed as a returned node. */
+template <typename F>
+bool rejects(F&& f) {
+    try {
+        auto n = f();
+        return n == nullptr || n->isErr() || n->isUnknown();
+    } catch (const std::exception&) {
+        return true;
+    }
+}
+
+} // namespace
+
+int main() {
+    std::cout << "======= numeric literals and the int/real exemption =======\n";
+
+    // ---- A literal really does carry IntOrReal. ----------------------------
+    {
+        // The premise. If this ever changes, the rest of the file is testing
+        // something other than what it claims to.
+        ParserPtr p = newParser();
+        VERIFY(p->mkConstInt(2)->getSort()->isIntOrReal());
+        VERIFY(p->mkVarInt("x")->getSort()->isInt());
+    }
+
+    // ---- Real division accepts an integer literal. -------------------------
+    {
+        // The original failure, in its smallest form: an Int variable divided
+        // by an integer literal.
+        ParserPtr p = newParser();
+        const auto q = p->mkDivReal(p->mkVarInt("x"), p->mkConstInt(2));
+        VERIFY(q != nullptr && !q->isErr() && !q->isUnknown());
+        VERIFY(q->getSort()->isReal());
+    }
+    {
+        // A Real variable and an integer literal, mixing the other way.
+        ParserPtr p = newParser();
+        const auto q = p->mkDivReal(p->mkVarReal("r"), p->mkConstInt(2));
+        VERIFY(q != nullptr && !q->isErr() && !q->isUnknown());
+        VERIFY(q->getSort()->isReal());
+    }
+
+    // ---- Integer division took the same route. -----------------------------
+    {
+        ParserPtr p = newParser();
+        const auto q = p->mkDivInt(p->mkVarInt("x"), p->mkConstInt(2));
+        VERIFY(q != nullptr && !q->isErr() && !q->isUnknown());
+        VERIFY(q->getSort()->isInt());
+    }
+
+    // ---- Through the parser, which is how a user meets it. -----------------
+    {
+        ParserPtr p = newParser();
+        VERIFY(p->parseStr("(declare-fun x () Int)\n(declare-fun r () Real)\n"
+                           "(assert (= r (/ x 2)))\n"));
+        VERIFY(has(p->dumpSMT2(), "(/ "));
+    }
+
+    // ---- The exemption is not a licence to mix anything. -------------------
+    {
+        // A Bool operand is still a type error. Without this, "fixing" the
+        // check by deleting it passes every assertion above.
+        ParserPtr p = newParser();
+        VERIFY(rejects([&] { return p->mkDivReal(p->mkVarBool("b"), p->mkConstInt(2)); }));
+    }
+
+    std::cout << "All int/real literal tests passed." << std::endl;
+    return 0;
+}

--- a/test/regression/test_mul_zero.cpp
+++ b/test/regression/test_mul_zero.cpp
@@ -1,0 +1,138 @@
+// `(* x 0)` came back as `x`.
+//
+// mkMul asked GlobalOptions which theory was active in order to decide what
+// kind of zero to return, and had no fallback:
+//
+//     if (isZero(params[i])) {
+//         if (options->isIntTheory())  return mkConstInt(0);
+//         else if (options->isRealTheory()) return mkConstReal(0.0);
+//     }                                   // <- and otherwise, nothing
+//     else if (isOne(params[i])) continue;
+//     else new_params.push_back(params[i]);
+//
+// When neither branch fired, control left the `if` without returning and
+// without pushing: the zero factor was added to neither the result nor
+// new_params, so it simply disappeared and the product became the product of
+// the remaining factors.
+//
+// The condition for that was not exotic. `isIntTheory()` wants an "I" and no
+// "R" in the logic string, `isRealTheory()` wants an "R", and the default logic
+// is **ALL** -- which contains neither. So every model built through the API
+// before a set-logic, which is every model this project's frontends build,
+// multiplied by zero and got its other factor back.
+//
+// Deciding by logic was wrong in the other direction too: under a mixed logic
+// such as AUFLIRA, isRealTheory() holds, and an Int-sorted product returned a
+// Real zero. Zero's sort follows the operands, not the logic.
+//
+// Found while checking that `a = b*div(a,b) + mod(a,b)` holds for the three
+// integer-division conventions: the identity failed at (1, -5), where the
+// Euclidean quotient is 0, and the missing factor was the zero.
+
+#include "somtparser/parser.h"
+
+#include <iostream>
+#include <string>
+
+#include "test_helpers.h"
+
+using namespace SOMTParser;
+
+namespace {
+
+bool has(const std::string& hay, const std::string& needle) {
+    return hay.find(needle) != std::string::npos;
+}
+
+} // namespace
+
+int main() {
+    std::cout << "======= multiplication by zero =======\n";
+
+    // ---- Constant folding: zero annihilates. -------------------------------
+    {
+        ParserPtr p = newParser();
+        const auto zero = p->mkConstInt(0);
+        // The original bug, in its smallest form. `-5` was the answer.
+        VERIFY(p->mkMul(p->mkConstInt(-5), zero)->toString() == "0");
+        VERIFY(p->mkMul(zero, p->mkConstInt(-5))->toString() == "0");
+        VERIFY(p->mkMul(p->mkConstInt(3), zero)->toString() == "0");
+        // n-ary, where the zero is neither first nor last: this returned the
+        // operator symbol alone, an even more obviously broken result that
+        // nothing was checking.
+        VERIFY(p->mkMul({p->mkConstInt(3), zero, p->mkConstInt(7)})->toString() == "0");
+        // And a product with no zero still multiplies.
+        VERIFY(p->mkMul(p->mkConstInt(-5), p->mkConstInt(2))->toString() == "-10");
+    }
+
+    // ---- A variable factor is annihilated just the same. -------------------
+    {
+        // This is the case that matters: with a constant the answer is at least
+        // a number, but `(* x 0)` returning `x` puts a free variable where a
+        // zero belongs, and every downstream consumer -- the printer, the
+        // evaluator, a solver -- agrees with it.
+        ParserPtr p = newParser();
+        const auto x = p->mkVarInt("x");
+        VERIFY(p->mkMul(x, p->mkConstInt(0))->toString() == "0");
+        VERIFY(p->mkMul(p->mkConstInt(0), x)->toString() == "0");
+    }
+
+    // ---- Addition is untouched: there, zero IS the identity. ---------------
+    {
+        // mkAdd drops zeroes on purpose and must keep doing so. Without this,
+        // "fixing" the two builders alike would be a plausible next step.
+        ParserPtr p = newParser();
+        const auto x = p->mkVarInt("x");
+        VERIFY(p->mkAdd(p->mkConstInt(-5), p->mkConstInt(0))->toString() == "-5");
+        VERIFY(p->mkAdd(x, p->mkConstInt(0))->toString() == "x");
+    }
+
+    // ---- One is still the multiplicative identity. -------------------------
+    {
+        ParserPtr p = newParser();
+        const auto x = p->mkVarInt("x");
+        VERIFY(p->mkMul(x, p->mkConstInt(1))->toString() == "x");
+    }
+
+    // ---- The zero's sort follows the operands, not the logic. --------------
+    {
+        // Under a mixed logic the old code took the isRealTheory() branch and
+        // handed back a Real zero for an Int product. Asserting through
+        // dumpSMT2 rather than on the node keeps this about the emitted script,
+        // which is what a solver reads.
+        ParserPtr p = newParser();
+        p->setOption("logic", "AUFLIRA");
+        const auto x = p->mkVarInt("x");
+        // Parser::assert is a member function, so parser.h #undefs the macro.
+        VERIFY(p->assert(p->mkEq(p->mkMul(x, p->mkConstInt(0)), p->mkConstInt(0))));
+        const std::string s = p->dumpSMT2();
+        VERIFY(!has(s, "0.0"));
+    }
+
+    // ---- Under an explicit Real logic it is a Real zero. --------------------
+    {
+        ParserPtr p = newParser();
+        const auto r = p->mkVarReal("r");
+        const auto prod = p->mkMul(r, p->mkConstReal(0.0));
+        VERIFY(prod->getSort()->isReal());
+    }
+
+    // ---- End to end: the division identity that found this. ----------------
+    {
+        // b*div(a,b) + mod(a,b) = a, at (1, -5) where the quotient is zero.
+        // Written through the same builders a frontend uses, so it fails if the
+        // annihilation regresses anywhere along that path rather than only in
+        // mkMul.
+        ParserPtr p = newParser();
+        const auto a = p->mkConstInt(1);
+        const auto b = p->mkConstInt(-5);
+        const auto q = p->mkDivInt(a, b);
+        const auto r = p->mkMod(a, b);
+        VERIFY(q->toString() == "0");
+        VERIFY(r->toString() == "1");
+        VERIFY(p->mkAdd(p->mkMul(b, q), r)->toString() == "1");
+    }
+
+    std::cout << "All multiplication-by-zero tests passed." << std::endl;
+    return 0;
+}

--- a/test/regression/test_quantifier_shadowing.cpp
+++ b/test/regression/test_quantifier_shadowing.cpp
@@ -1,0 +1,130 @@
+// A quantifier binder that shadows an enclosing one keeps its own sort.
+//
+//     (forall ((x Int)) (and (P x) (forall ((x (_ BitVec 8))) (Q x))))
+//
+// parsed, printed and reported success as
+//
+//     (forall ((x Int)) (and (P x) (forall ((x Int))          (Q x))))
+//
+// so Q -- declared over (_ BitVec 8) -- was applied to an Int. Shadowing is
+// legal SMT-LIB, so this was a well-formed input silently turned into a
+// different problem, with no diagnostic anywhere.
+//
+// Two independent causes, and either one alone produces a wrong answer:
+//
+//   * mkQuantVar looked up an existing binder BY NAME and returned it whatever
+//     its sort, so the inner binder simply became the outer one.
+//   * popQuantScope erases by name. That is right when nothing was shadowed and
+//     wrong when something was: leaving the inner scope removed the outer
+//     binding too, and the outer body's remaining occurrences of `x` then
+//     resolved as free symbols.
+//
+// The two groups below separate them: the first is about the inner binder's
+// sort, the second about the outer binding still being there afterwards.
+
+#include "somtparser/parser.h"
+
+#include <iostream>
+#include <string>
+
+#include "test_helpers.h"
+
+using namespace SOMTParser;
+
+namespace {
+
+bool has(const std::string& hay, const std::string& needle) {
+    return hay.find(needle) != std::string::npos;
+}
+
+std::string dumpOf(const std::string& src) {
+    ParserPtr p = newParser();
+    VERIFY(p->parseStr(src));
+    return p->dumpSMT2();
+}
+
+} // namespace
+
+int main() {
+    std::cout << "======= shadowed quantifier binders =======\n";
+
+    // ---- The inner binder keeps its own sort. ------------------------------
+    {
+        const std::string s = dumpOf(
+            "(declare-fun P (Int) Bool)\n"
+            "(declare-fun Q ((_ BitVec 8)) Bool)\n"
+            "(assert (forall ((x Int)) (and (P x) (forall ((x (_ BitVec 8))) (Q x)))))\n");
+        // Both sorts survive. The defect printed the inner binder as Int, so
+        // the BitVec 8 vanished from the script entirely and Q was applied to
+        // an argument of the wrong sort.
+        VERIFY(has(s, "(x (_ BitVec 8))"));
+        VERIFY(has(s, "(x Int)"));
+    }
+    {
+        // The reverse nesting, so the fix is not "BitVec wins".
+        const std::string s = dumpOf(
+            "(declare-fun P (Int) Bool)\n"
+            "(declare-fun Q ((_ BitVec 8)) Bool)\n"
+            "(assert (forall ((x (_ BitVec 8))) (and (Q x) (forall ((x Int)) (P x)))))\n");
+        VERIFY(has(s, "(x (_ BitVec 8))"));
+        VERIFY(has(s, "(x Int)"));
+    }
+    {
+        // Shadowing at the SAME sort is legal and must still work -- there the
+        // inner binder may legitimately reuse the node.
+        const std::string s = dumpOf(
+            "(declare-fun P (Int) Bool)\n"
+            "(assert (forall ((x Int)) (and (P x) (forall ((x Int)) (P x)))))\n");
+        VERIFY(has(s, "(x Int)"));
+    }
+
+    // ---- The outer binding survives the inner scope. -----------------------
+    {
+        // `(P x)` comes AFTER the inner quantifier here, so it is resolved once
+        // the inner scope has been left. With popQuantScope erasing rather than
+        // restoring, `x` was already gone.
+        const std::string s = dumpOf(
+            "(declare-fun P (Int) Bool)\n"
+            "(declare-fun Q ((_ BitVec 8)) Bool)\n"
+            "(assert (forall ((x Int)) (and (forall ((x (_ BitVec 8))) (Q x)) (P x))))\n");
+        VERIFY(has(s, "(x (_ BitVec 8))"));
+        VERIFY(has(s, "(x Int)"));
+    }
+    {
+        // Three deep, so a fix that restores exactly one level is not enough.
+        const std::string s = dumpOf(
+            "(declare-fun P (Int) Bool)\n"
+            "(declare-fun Q ((_ BitVec 8)) Bool)\n"
+            "(declare-fun R (Real) Bool)\n"
+            "(assert (forall ((x Int))"
+            " (and (forall ((x (_ BitVec 8))) (and (Q x) (forall ((x Real)) (R x))))"
+            "      (P x))))\n");
+        VERIFY(has(s, "(x Int)"));
+        VERIFY(has(s, "(x (_ BitVec 8))"));
+        VERIFY(has(s, "(x Real)"));
+    }
+
+    // ---- Distinct names were always fine, and must stay so. ----------------
+    {
+        const std::string s = dumpOf(
+            "(declare-fun P (Int) Bool)\n"
+            "(declare-fun Q ((_ BitVec 8)) Bool)\n"
+            "(assert (forall ((x Int)) (and (P x) (forall ((y (_ BitVec 8))) (Q y)))))\n");
+        VERIFY(has(s, "(x Int)"));
+        VERIFY(has(s, "(y (_ BitVec 8))"));
+    }
+
+    // ---- Sibling scopes, not nested: the second must not inherit the first. -
+    {
+        const std::string s = dumpOf(
+            "(declare-fun P (Int) Bool)\n"
+            "(declare-fun Q ((_ BitVec 8)) Bool)\n"
+            "(assert (and (forall ((x Int)) (P x))"
+            "             (forall ((x (_ BitVec 8))) (Q x))))\n");
+        VERIFY(has(s, "(x Int)"));
+        VERIFY(has(s, "(x (_ BitVec 8))"));
+    }
+
+    std::cout << "All quantifier-shadowing tests passed." << std::endl;
+    return 0;
+}


### PR DESCRIPTION
Four engine defects that share one shape: **a well-formed input is accepted, silently
changed into a different problem, and reported as a success.** No diagnostic, no failed
round trip — just a different answer.

All four were found while building a frontend on top of this engine, and all four are
pre-existing on `main`.

## The defects

| | Input | Before | Correct |
|---|---|---|---|
| 1 | `(div 1 -5)`, `(mod 1 -5)` | `-1`, `1` — and `-5*(-1)+1 = 6 ≠ 1` | `0`, `1` |
| 2 | `(* x 0)` | `x` | `0` |
| 3 | `(/ x 2)` on an Int `x` | `Type mismatch in div` | builds |
| 4 | `(forall ((x Int)) … (forall ((x (_ BitVec 8))) (Q x)))` | inner binder prints as `(x Int)` | keeps `(_ BitVec 8)` |

**1 — div and mod came from two different conventions.** `floorDiv` rounds toward −∞ and
C++'s `%` truncates toward zero, so the quotient and the remainder were computed under
different definitions and `a = b*q + r` — the identity that defines both — did not hold for
a negative divisor. Not a wrong choice of convention; a mix of two. Both are now Euclidean,
which is what SMT-LIB specifies.

**2 — the zero factor was dropped.** `mkMul` chose the kind of zero to return by asking
`GlobalOptions` which theory was active, with no fallback; when neither `isIntTheory()` nor
`isRealTheory()` held, control left the `if` without returning and without pushing the
factor. The default logic is `ALL`, whose string contains neither `I` nor `R`, so this hit
every model built through the API before a `set-logic`. Deciding by logic was also wrong
where it did fire: under `AUFLIRA` an Int-sorted product returned a Real zero. Zero's sort
follows the operands.

**3 — a numeric literal's sort was not in the int/real exemption list.** `canExempt` listed
`Int` and `Real`; a literal carries `IntOrReal`. So the exemption held everywhere except
where a literal met an operator that wants Reals. `getSort()`, twenty lines below in the
same file, already asked `isIntOrReal()`.

**4 — a shadowed quantifier binder took the outer binder's sort.** Two independent causes:
`mkQuantVar` matched an existing binder by name and returned it whatever its sort, and
`popQuantScope` erases by name — right when nothing was shadowed, wrong when something was,
since leaving the inner scope removed the outer binding too. Shadowing is legal SMT-LIB.

## Tests

Four regression files, each separating the halves of its fix rather than asserting one
happy path. The shadowing test covers three nesting levels, sibling scopes, same-sort
shadowing and distinct names, so a fix that special-cases one shape does not pass; the
literal test asserts its own premise (that `2` really does carry `IntOrReal`) and that a
Bool operand is still refused, so deleting the check entirely does not pass either.

Four breakage probes — each fix reverted in turn, its test confirmed to fail, then
restored. All four caught.

## Verification

`44/44` C++ tests and `188/188` Python, clean configure and build from `origin/main`.

## Note on how these were found

Every one surfaced from a **property** rather than an example: an arithmetic identity
(`a = b*q + r`) and a round trip (`text → parse → IR → parse → text`). Example tests
confirm what you already thought to write down; these four were all in the space nobody
had thought to write down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)