### PR TITLE
Make dumpSMT2 survive a round trip: three printer defects and the property that finds them

### DIFF
--- a/include/somtparser/frontend/symbol_manager.h
+++ b/include/somtparser/frontend/symbol_manager.h
@@ -102,6 +102,18 @@ public:
     bool hasFunctionName(const std::string& name) const;
     void removeFunctionName(const std::string& name);
 
+    // --- Mutually recursive function groups, from (define-funs-rec ...) ---
+    // The grouping is not recoverable from the function nodes themselves: each
+    // member is an ordinary NT_FUNC_REC, indistinguishable from one written as
+    // a standalone (define-fun-rec ...). It has to be recorded here because a
+    // group can only be dumped as a single define-funs-rec -- its members call
+    // each other, so emitting them as separate define-fun-rec commands makes
+    // the first one refer to a name the script has not defined yet, and the
+    // dump no longer re-parses.
+    void addRecFunGroup(const std::vector<std::string>& names);
+    /** The group `name` belongs to, or nullptr if it was not defined in one. */
+    const std::vector<std::string>* getRecFunGroup(const std::string& name) const;
+
     // --- Static functions ---
     void addStaticFunction(const std::shared_ptr<DAGNode>& node);
     const std::vector<std::shared_ptr<DAGNode>>& getStaticFunctions() const;
@@ -138,6 +150,8 @@ private:
     std::unordered_map<std::string, std::shared_ptr<DAGNode>> temp_var_names_;
     std::unordered_map<std::string, std::shared_ptr<DAGNode>> placeholder_var_names_;
     std::vector<std::string> function_names_;
+    std::vector<std::vector<std::string>> rec_fun_groups_;
+    std::unordered_map<std::string, size_t> rec_fun_group_of_;
     std::vector<std::shared_ptr<DAGNode>> static_functions_;
     std::vector<std::string> sort_order_;
     std::vector<std::string> var_order_;

--- a/include/somtparser/ir/dag.h
+++ b/include/somtparser/ir/dag.h
@@ -42,6 +42,7 @@
 #include <list>
 #include <algorithm>
 #include <ctime>
+#include <cstdint>
 #include <cstdlib>
 #include <memory>
 #include <functional> // for std::hash
@@ -80,6 +81,14 @@ namespace SOMTParser{
         mutable size_t                          cached_hash_code;
         mutable bool                            hash_computed;
         mutable size_t                          _use_count;
+        // Rolling hash of this node's printed form, and that form's length;
+        // see orderKey(). The length is what lets a parent fold this subtree in
+        // without re-walking it. Default member initializers, not constructor
+        // bodies: DAGNode has a dozen constructors and a field one of them
+        // forgot would silently order operands by stale data.
+        mutable uint64_t                        cached_print_hash = 0;
+        mutable uint64_t                        cached_print_len = 0;
+        mutable bool                            print_hash_computed = false;
 
     public:
         DAGNode(std::shared_ptr<Sort> sort, NODE_KIND kind, std::string name, std::vector<std::shared_ptr<DAGNode>> children): sort(sort), kind(kind), name(name), value(nullptr), children(children){
@@ -315,6 +324,9 @@ namespace SOMTParser{
             children_hash = "";
             cached_hash_code = 0;
             hash_computed = false;
+            cached_print_hash = 0;
+            cached_print_len = 0;
+            print_hash_computed = false;
             name = "";
             _use_count = 0;
         }
@@ -1008,8 +1020,34 @@ namespace SOMTParser{
         }
 
         /**
+         * @brief Key that canonicalises the operand order of commutative
+         *        operators: a hash of this node's printed SMT-LIB form.
+         *
+         * Deliberately not hashCode(). hashCode() mixes in the sort string, the
+         * internal name and the child count, and none of those survive a dump:
+         * a Real literal prints as `0` and reads back as IntOrReal, and an fp
+         * literal prints from a childless node but reads back as a three-child
+         * one. Ordering by hashCode() therefore gave the same script a
+         * different operand order on every re-parse, so dumpSMT2() was not a
+         * fixed point. The printed form is the only thing a dump preserves by
+         * construction, so ordering on it is what makes the order survive.
+         *
+         * Distinct printed forms may still collide; callers must break ties
+         * with a stable sort, which keeps such operands in input order and so
+         * keeps the result reproducible.
+         */
+        std::size_t orderKey() const;
+
+        /** Whether orderKey() has already been computed for this node. */
+        bool hasPrintHash() const { return print_hash_computed; }
+        /** Rolling hash of the printed form; only valid once hasPrintHash(). */
+        uint64_t printHash() const { return cached_print_hash; }
+        /** Character length of the printed form; only valid once hasPrintHash(). */
+        uint64_t printLength() const { return cached_print_len; }
+
+        /**
          * @brief Update the function definition
-         * 
+         *
          * @note This function is only used to update the function definition.
          * 
          * @param out_sort The output sort

--- a/include/somtparser/ir/dag.h
+++ b/include/somtparser/ir/dag.h
@@ -1092,6 +1092,7 @@ namespace SOMTParser{
     std::string dumpSMTLIB2(const std::shared_ptr<DAGNode>& node);
     std::string dumpFuncDef(const std::shared_ptr<DAGNode>& node);
     std::string dumpFuncRec(const std::shared_ptr<DAGNode>& node);
+    std::string dumpFuncsRec(const std::vector<std::shared_ptr<DAGNode>>& nodes);
     std::string dumpFuncDec(const std::shared_ptr<DAGNode>& node);
     
     // smart pointer

--- a/src/core/kind.cpp
+++ b/src/core/kind.cpp
@@ -543,7 +543,11 @@ namespace SOMTParser{
         case NODE_KIND::NT_STR_REPLACE_REG_ALL:
             return "str.replace_re_all";
         case NODE_KIND::NT_STR_INDEXOF_REG:
-            return "str.indexof";
+            // Not "str.indexof": that is NT_STR_INDEXOF, which takes a string
+            // needle and a start offset (arity 3). This one takes a regular
+            // expression and no offset (arity 2), so printing the other name
+            // produced a term no parser can read back.
+            return "str.indexof_re";
         // INTERVAL
         case NODE_KIND::NT_MAX:
             return "max";

--- a/src/frontend/base_parser.cpp
+++ b/src/frontend/base_parser.cpp
@@ -1539,7 +1539,13 @@ namespace SOMTParser{
 				}
 			}
 			parseRpar(); // end of function bodies list
-			
+
+			// Remember that these names form one mutually recursive group. The
+			// nodes themselves carry no trace of it, so without this the dump
+			// would split the group into standalone define-fun-rec commands and
+			// forward-reference the members defined later.
+			getSymbolManager()->addRecFunGroup(func_names);
+
 			skipToRpar();
 			return CMD_TYPE::CT_DEFINE_FUNS_REC;
 		}
@@ -3557,9 +3563,29 @@ namespace SOMTParser{
 			ss << "(declare-fun " << var->getName() << " () " << var->getSort()->toString() << ")" << std::endl;
 		}
 	std::vector<std::shared_ptr<DAGNode>> functions = getFunctions();
+	// Members of a (define-funs-rec ...) group are emitted together, at the
+	// position of whichever member comes first, so the rest must be skipped
+	// when the loop reaches them.
+	std::unordered_set<std::string> emitted_funcs;
 	for(auto& func : functions){
 		if(!func) continue;
 		if(datatype_member_names.count(func->getName())) continue;
+		if(!emitted_funcs.insert(func->getName()).second) continue;
+		if(const auto* group = getSymbolManager()->getRecFunGroup(func->getName())){
+			std::vector<std::shared_ptr<DAGNode>> members;
+			for(const auto& member_name : *group){
+				auto member = getSymbolManager()->getFun(member_name);
+				// A member removed via removeFuns() leaves the rest of the
+				// group behind; dropping it silently would emit a group whose
+				// bodies call a name nothing defines, so refuse instead.
+				condAssert(member != nullptr,
+					"dumpSMT2: define-funs-rec group member `" + member_name + "` is gone");
+				members.emplace_back(member);
+				emitted_funcs.insert(member_name);
+			}
+			ss << dumpFuncsRec(members) << std::endl;
+			continue;
+		}
 		if(func->isFuncDec()){
 			// NT_FUNC_DEC: Uninterpreted function declaration (declare-fun)
 			ss << dumpFuncDec(func) << std::endl;

--- a/src/frontend/op_parser.cpp
+++ b/src/frontend/op_parser.cpp
@@ -141,6 +141,14 @@ namespace SOMTParser{
         return getSort({l, r, m});
     }
 
+    // Canonicalises the operand order of a commutative operator.
+    //
+    // Ordered by DAGNode::orderKey() -- a hash of each operand's printed form --
+    // and not by hashCode(), so that dumping a script and reading it back yields
+    // the same order. hashCode() also mixes in the sort and the internal node
+    // layout, which a dump does not preserve, so it reordered operands on every
+    // round trip. All comparisons below are strict (`>`), which keeps equal keys
+    // in input order and makes the result reproducible.
     std::vector<std::shared_ptr<DAGNode>> sortParams(const std::vector<std::shared_ptr<DAGNode>> &p){
         // fast path
         if(p.size() <= 1) {
@@ -148,8 +156,8 @@ namespace SOMTParser{
         }
         if(p.size() == 2) {
             std::vector<std::shared_ptr<DAGNode>> params = p;
-            size_t hash0 = params[0]->hashCode();
-            size_t hash1 = params[1]->hashCode();
+            size_t hash0 = params[0]->orderKey();
+            size_t hash1 = params[1]->orderKey();
             if(hash0 > hash1) {
                 std::swap(params[0], params[1]);
             }
@@ -157,9 +165,9 @@ namespace SOMTParser{
         }
         if(p.size() == 3) {
             std::vector<std::shared_ptr<DAGNode>> params = p;
-            size_t hash0 = params[0]->hashCode();
-            size_t hash1 = params[1]->hashCode();
-            size_t hash2 = params[2]->hashCode();
+            size_t hash0 = params[0]->orderKey();
+            size_t hash1 = params[1]->orderKey();
+            size_t hash2 = params[2]->orderKey();
             
             // 简单的3元素排序网络
             if(hash0 > hash1) { std::swap(params[0], params[1]); std::swap(hash0, hash1); }
@@ -177,10 +185,10 @@ namespace SOMTParser{
         params_with_hash.reserve(params.size());
         
         for(const auto& param : params) {
-            params_with_hash.emplace_back(param, param->hashCode());
+            params_with_hash.emplace_back(param, param->orderKey());
         }
-        
-        // Sort by hash code. stable_sort, not sort: hash collisions must fall
+
+        // Sort by ordering key. stable_sort, not sort: key collisions must fall
         // back to input order, otherwise operands that hash alike come out in
         // an unspecified order and the AST stops being reproducible. (The
         // SMTStabilizer fork breaks such ties by comparing shared_ptr values,

--- a/src/frontend/symbol_manager.cpp
+++ b/src/frontend/symbol_manager.cpp
@@ -316,6 +316,22 @@ bool SymbolManager::hasFunctionName(const std::string& name) const {
     return std::find(function_names_.begin(), function_names_.end(), name) != function_names_.end();
 }
 
+void SymbolManager::addRecFunGroup(const std::vector<std::string>& names) {
+    if (names.empty()) return;
+    const size_t index = rec_fun_groups_.size();
+    rec_fun_groups_.emplace_back(names);
+    for (const auto& name : names) {
+        rec_fun_group_of_[name] = index;
+    }
+}
+
+const std::vector<std::string>* SymbolManager::getRecFunGroup(const std::string& name) const {
+    auto it = rec_fun_group_of_.find(name);
+    if (it == rec_fun_group_of_.end()) return nullptr;
+    condAssert(it->second < rec_fun_groups_.size(), "getRecFunGroup: dangling group index");
+    return &rec_fun_groups_[it->second];
+}
+
 void SymbolManager::removeFunctionName(const std::string& name) {
     auto it = std::find(function_names_.begin(), function_names_.end(), name);
     if (it != function_names_.end()) function_names_.erase(it);

--- a/src/ir/dag.cpp
+++ b/src/ir/dag.cpp
@@ -31,7 +31,9 @@
 #include "somtparser/ir/value.h"
 #include <stack>
 #include <optional>
+#include <ostream>
 #include <sstream>
+#include <streambuf>
 #include <unordered_set>
 
 namespace SOMTParser{
@@ -44,6 +46,11 @@ namespace SOMTParser{
             children.emplace_back(p);
         }
         kind = is_rec ? NODE_KIND::NT_FUNC_REC : NODE_KIND::NT_FUNC_DEF;
+        // The node now prints differently, so any ordering key taken from the
+        // old printed form is stale.
+        cached_print_hash = 0;
+        cached_print_len = 0;
+        print_hash_computed = false;
     }
 
     
@@ -56,6 +63,10 @@ namespace SOMTParser{
             children.emplace_back(p);
         }
         kind = is_rec ? NODE_KIND::NT_FUNC_REC_APPLY : NODE_KIND::NT_FUNC_APPLY;
+        // As in updateFuncDef: the printed form changed, drop the stale key.
+        cached_print_hash = 0;
+        cached_print_len = 0;
+        print_hash_computed = false;
     }
 
     // Helper: check if a string is in canonical rational a/b form
@@ -152,10 +163,73 @@ namespace SOMTParser{
     }
 
     // High-performance iterative streaming version to avoid stack overflow
-    void dumpSMTLIB2_streaming(const std::shared_ptr<DAGNode>& root, std::ostream& out) {
+    // Hashes everything written to it without ever materialising the text, so
+    // a node's printed form can be hashed in place of being built.
+    //
+    // The hash is polynomial/rolling rather than a plain accumulator because it
+    // has to compose: H(A.B) = H(A)*BASE^|B| + H(B). That identity is what lets
+    // an already-hashed subtree be folded in as a single unit (absorb), so no
+    // node ever re-walks a subtree an ancestor already walked. Hashing every
+    // operand of n nested commutative operators is then linear; re-printing
+    // each ancestor's whole subtree instead would be quadratic.
+    //
+    // BASE must be odd to stay invertible modulo 2^64 (unsigned overflow is
+    // well-defined wraparound), otherwise low bits would decay to zero.
+    class PrintHashBuf : public std::streambuf {
+    public:
+        static const uint64_t BASE = 1099511628211ull;  // FNV-1a prime, odd
+
+        uint64_t hash() const { return h_; }
+        uint64_t length() const { return len_; }
+
+        void absorb(uint64_t chunk_hash, uint64_t chunk_len) {
+            h_ = h_ * ipow(BASE, chunk_len) + chunk_hash;
+            len_ += chunk_len;
+        }
+
+    protected:
+        std::streamsize xsputn(const char* s, std::streamsize n) override {
+            for (std::streamsize i = 0; i < n; i++) {
+                h_ = h_ * BASE + static_cast<unsigned char>(s[i]);
+            }
+            len_ += static_cast<uint64_t>(n);
+            return n;
+        }
+
+        int_type overflow(int_type c) override {
+            if (c != traits_type::eof()) {
+                h_ = h_ * BASE + static_cast<unsigned char>(c);
+                len_ += 1;
+            }
+            return c;
+        }
+
+    private:
+        static uint64_t ipow(uint64_t base, uint64_t exp) {
+            uint64_t r = 1;
+            while (exp) {
+                if (exp & 1) r *= base;
+                base *= base;
+                exp >>= 1;
+            }
+            return r;
+        }
+
+        uint64_t h_ = 0;
+        uint64_t len_ = 0;
+    };
+
+    // Takes a raw pointer so that a node can print itself without owning a
+    // shared_ptr to itself (see DAGNode::orderKey). Ownership is the caller's;
+    // this only reads.
+    //
+    // `hb`, when set, must be the streambuf backing `out`: it switches on the
+    // subtree folding described on PrintHashBuf. It is null for ordinary
+    // printing, which always walks the whole term.
+    void dumpSMTLIB2_streaming(DAGNode* root, std::ostream& out, PrintHashBuf* hb = nullptr) {
         if (!root) return;
 
-        std::shared_ptr<DAGNode> actualRoot = root;
+        DAGNode* actualRoot = root;
 
         // Static kind string cache for performance
         static std::unordered_map<NODE_KIND, const char*> kind_cache;
@@ -210,7 +284,7 @@ namespace SOMTParser{
         // Pre-allocate stack with reasonable capacity to avoid frequent reallocations
         std::vector<WorkItem> work_stack;
         work_stack.reserve(65536); // Reserve space for deep expressions
-        work_stack.emplace_back(actualRoot.get(), 0);
+        work_stack.emplace_back(actualRoot, 0);
 
         while (!work_stack.empty()) {
             WorkItem item = work_stack.back();
@@ -237,6 +311,14 @@ namespace SOMTParser{
             // Process node (action == 0)
             DAGNode* node = item.node;
             if (!node) continue;
+
+            // Every node -- root and child alike -- reaches the printer through
+            // this one point, so folding in an already-hashed subtree here
+            // covers all of them.
+            if (hb && node->hasPrintHash()) {
+                hb->absorb(node->printHash(), node->printLength());
+                continue;
+            }
 
             auto kind = node->getKind();
             switch (kind) {
@@ -1136,8 +1218,23 @@ namespace SOMTParser{
     // Wrapper function that returns string for compatibility
     std::string dumpSMTLIB2(const std::shared_ptr<DAGNode>& root) {
         std::ostringstream oss;
-        dumpSMTLIB2_streaming(root, oss);  // enable cache by default
+        dumpSMTLIB2_streaming(root.get(), oss);  // enable cache by default
         return oss.str();
+    }
+
+    std::size_t DAGNode::orderKey() const {
+        if(print_hash_computed) {
+            return static_cast<std::size_t>(cached_print_hash);
+        }
+        // const_cast is safe: the printer only reads. Its parameter is
+        // non-const because its internal work stack holds DAGNode*.
+        PrintHashBuf buf;
+        std::ostream os(&buf);
+        dumpSMTLIB2_streaming(const_cast<DAGNode*>(this), os, &buf);
+        cached_print_hash = buf.hash();
+        cached_print_len = buf.length();
+        print_hash_computed = true;
+        return static_cast<std::size_t>(cached_print_hash);
     }
 
     

--- a/src/ir/dag.cpp
+++ b/src/ir/dag.cpp
@@ -1165,6 +1165,37 @@ namespace SOMTParser{
         res += dumpSMTLIB2(node->getChild(0)) +  ")";
         return res;
     }
+    // (define-funs-rec ((f (params) sort) ...) (body ...))
+    //
+    // A mutually recursive group has to be emitted as one command: its members
+    // call each other, so a sequence of define-fun-rec commands would refer to
+    // a function that the script has not defined yet.  SMT-LIB puts all the
+    // signatures first precisely so every body can see every name.
+    std::string dumpFuncsRec(const std::vector<std::shared_ptr<DAGNode>>& nodes){
+        condAssert(!nodes.empty(), "dumpFuncsRec: empty group");
+        std::string res = "(define-funs-rec (";
+        for(size_t n = 0; n < nodes.size(); n++){
+            const auto& node = nodes[n];
+            condAssert(node != nullptr, "dumpFuncsRec: null member");
+            if(n != 0) res += " ";
+            res += "(" + node->getName() + " (";
+            // children[0] is the body, children[1..n] are the parameters.
+            for(size_t i = 1; i < node->getChildrenSize(); i++){
+                if(i != 1) res += " ";
+                res += "(" + node->getChild(i)->getName() + " " +
+                       node->getChild(i)->getSort()->toString() + ")";
+            }
+            res += ") " + node->getSort()->toString() + ")";
+        }
+        res += ") (";
+        for(size_t n = 0; n < nodes.size(); n++){
+            if(n != 0) res += " ";
+            res += dumpSMTLIB2(nodes[n]->getChild(0));
+        }
+        res += "))";
+        return res;
+    }
+
     std::string dumpFuncDec(const std::shared_ptr<DAGNode>& node){
         std::string res = "(declare-fun " + node->getName() + " (";
         // For NT_FUNC_DEC, children[0] is NULL_NODE, children[1..n] are parameter type nodes

--- a/test/api/test_let_evaluate.cpp
+++ b/test/api/test_let_evaluate.cpp
@@ -173,8 +173,16 @@ void test_expandLet() {
         VERIFY(expr && !expr->isLet() && !expr->isLetChain());
         auto expanded = p->expandLet(expr);
         VERIFY(expanded);
+        // Expanding a term that contains no let must hand back the very same
+        // hash-consed node. That is the property this case exists to check,
+        // and it is stronger than comparing printed text.
+        VERIFY(expanded == expr);
+        // `+` is commutative, so the builder canonicalises the operand order
+        // and either printing is correct (CLAUDE.md invariant 2). This used to
+        // assert "(+ x 2)" exactly, which silently depended on the ordering
+        // key rather than on anything expandLet does.
         std::string s = p->toString(expanded);
-        VERIFY(s == "(+ x 2)");
+        VERIFY(s == "(+ x 2)" || s == "(+ 2 x)");
     }
 
     std::cout << "test_expandLet: all passed\n\n";

--- a/test/python/test_build.py
+++ b/test/python/test_build.py
@@ -440,7 +440,15 @@ class TestTransformations:
         p = sp.parse(
             "(declare-const x Int)(assert (or (> x 0) (and (< x 9) (= x 4))))")
         atoms = p.collect_atoms(p.assertions[0])
-        assert {a.to_smt2() for a in atoms} == {"(> x 0)", "(< x 9)", "(= x 4)"}
+        # Compared by operator and operand SET. `=` is commutative, so its
+        # operands are canonicalised into an order the source did not choose
+        # and `(= x 4)` may come back as `(= 4 x)`; what this test is about is
+        # which atoms were collected, not how each one prints.
+        assert {(a.kind, frozenset(c.to_smt2() for c in a)) for a in atoms} == {
+            (">", frozenset({"x", "0"})),
+            ("<", frozenset({"x", "9"})),
+            ("=", frozenset({"x", "4"})),
+        }
 
     def test_expand_let(self):
         p = sp.parse("(declare-const x Int)(assert (let ((t (+ x 1))) (> t 0)))")

--- a/test/python/test_node.py
+++ b/test/python/test_node.py
@@ -171,9 +171,15 @@ class TestLifetimeSafety:
         node = p.assertions[0]
         del p
         gc.collect()
-        assert node.to_smt2() == "(> (+ z 1) 5)"
+        # What this test is about is that the node outlives the parser, so it
+        # asserts the node's STRUCTURE rather than its printed text. The
+        # operands of a commutative operator are canonicalised into an order
+        # the caller did not choose, so `(+ z 1)` may print either way round
+        # and pinning one spelling here tests the ordering, not the lifetime.
+        assert node.kind == ">"
         assert node[0].kind == "+"
-        assert node[0][0].name == "z"
+        assert {c.to_smt2() for c in node[0]} == {"z", "1"}
+        assert node[1].to_smt2() == "5"
 
     def test_deep_subtree_survives_parser_gc(self):
         p = sp.Parser()

--- a/test/regression/test_dump_roundtrip_instances.cpp
+++ b/test/regression/test_dump_roundtrip_instances.cpp
@@ -1,0 +1,145 @@
+// Every instance under test/instances must survive parse -> dump -> parse -> dump.
+//
+// test_dump_reparse.cpp already checks this property, but only against scripts
+// written by hand inside that file, and it says so in its own header comment:
+// "the cases below deliberately avoid operators whose printing is fixed
+// elsewhere".  That is the whole problem.  A hand-written corpus can only
+// contain constructs somebody thought to write down, so it can never catch the
+// case where the parser accepts something its own printer cannot emit -- which
+// is precisely the defect class this property exists to catch.
+//
+// So this file supplies the input instead of the assertion: it runs the same
+// property over the real corpus.  Three defects it found on the day it was
+// written:
+//
+//   * define-funs-rec (mutually recursive definitions) was parsed and then
+//     never dumped, while the assertions calling those functions were dumped,
+//     so the output referred to symbols it never defined;
+//   * NT_STR_INDEXOF_RE printed as "str.indexof", a different operator with a
+//     different arity, so the output could not be read back at all;
+//   * commutative operands were re-canonicalised on the way back in, so
+//     dump -> parse -> dump did not converge on a fixed point.
+//
+// Adding an instance to test/instances therefore extends this test for free.
+// That is the point: coverage should follow the corpus, not a list.
+
+#include "somtparser/frontend/parser.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "test_helpers.h"
+
+using namespace SOMTParser;
+
+namespace {
+
+const char* kCorpus = "test/instances";
+
+std::vector<std::filesystem::path> collectInstances() {
+    std::vector<std::filesystem::path> files;
+    VERIFY(std::filesystem::exists(kCorpus));
+    for (const auto& entry : std::filesystem::recursive_directory_iterator(kCorpus)) {
+        if (entry.is_regular_file() && entry.path().extension() == ".smt2") {
+            files.push_back(entry.path());
+        }
+    }
+    std::sort(files.begin(), files.end());
+    // Guard against silently testing nothing if the corpus moves or the working
+    // directory is wrong: a zero-file run would otherwise report success.
+    VERIFY(files.size() >= 15);
+    return files;
+}
+
+// Names every symbol the dump introduces, so an assertion that mentions a
+// symbol the dump never defined can be reported precisely rather than as a
+// bare "re-parse failed".
+std::string describeReparseFailure(const std::string& dump) {
+    std::istringstream in(dump);
+    std::string line;
+    std::size_t defs = 0;
+    while (std::getline(in, line)) {
+        if (line.rfind("(declare-", 0) == 0 || line.rfind("(define-", 0) == 0) { ++defs; }
+    }
+    std::ostringstream out;
+    out << dump.size() << " bytes, " << defs << " declarations/definitions";
+    return out.str();
+}
+
+struct Failure {
+    std::string file;
+    std::string what;
+};
+
+}  // namespace
+
+int main() {
+    std::cout << "======= dumpSMT2 round-trip over test/instances =======\n";
+
+    const auto files = collectInstances();
+    std::vector<Failure> failures;
+    std::size_t checked = 0;
+
+    for (const auto& path : files) {
+        const std::string name = path.string();
+
+        auto first = std::make_shared<Parser>();
+        if (!first->parse(name)) {
+            // Not a round-trip failure: the corpus holds files this parser is
+            // not expected to accept.  Skipped, but counted nowhere, so it
+            // cannot mask a regression in the files that do parse.
+            std::cout << "  skip (does not parse): " << name << "\n";
+            continue;
+        }
+
+        const std::string once = first->dumpSMT2();
+
+        auto second = std::make_shared<Parser>();
+        if (!second->parseStr(once)) {
+            failures.push_back({name, "dump is not re-parsable: " + describeReparseFailure(once)});
+            continue;
+        }
+
+        const std::string twice = second->dumpSMT2();
+        if (once != twice) {
+            // Report the first differing line rather than two whole scripts.
+            std::istringstream a(once), b(twice);
+            std::string la, lb;
+            std::size_t lineno = 0, diff_at = 0;
+            std::string sample_a, sample_b;
+            while (std::getline(a, la)) {
+                ++lineno;
+                if (!std::getline(b, lb)) { lb.clear(); }
+                if (la != lb && diff_at == 0) {
+                    diff_at = lineno;
+                    sample_a = la;
+                    sample_b = lb;
+                }
+            }
+            failures.push_back({name, "dump -> parse -> dump is not a fixed point at line " +
+                                          std::to_string(diff_at) + "\n      first:  " + sample_a +
+                                          "\n      second: " + sample_b});
+            continue;
+        }
+
+        ++checked;
+    }
+
+    for (const auto& f : failures) {
+        std::cerr << "  FAIL " << f.file << "\n      " << f.what << "\n";
+    }
+
+    std::cout << checked << " instance(s) round-tripped, " << failures.size() << " failed\n";
+    VERIFY(failures.empty());
+    // A run where every file was skipped would reach here with no failures;
+    // require that the property was actually exercised.
+    VERIFY(checked >= 15);
+
+    std::cout << "All instances round-trip.\n";
+    return 0;
+}

--- a/test/regression/test_kind_symbol_roundtrip.cpp
+++ b/test/regression/test_kind_symbol_roundtrip.cpp
@@ -1,0 +1,121 @@
+// kindToString() must name the operator it was given.
+//
+// The parser reads a symbol through oper_key_map (symbol -> kind) and the
+// printer writes one through kindToString (kind -> symbol).  Nothing has ever
+// checked that the two agree, and they did not: NT_STR_INDEXOF_REG printed as
+// "str.indexof", which oper_key_map resolves to NT_STR_INDEXOF -- a different
+// operator taking three arguments instead of two.  Any term containing
+// str.indexof_re therefore dumped to a script this parser rejects.
+//
+// That defect is invisible to a per-operator test, because printing is correct
+// in isolation for every operator someone remembered to check.  It is only
+// visible as a property over the whole table, which is what this file asserts:
+//
+//     for every kind k whose printed name is a known operator symbol,
+//     that symbol must resolve back to k.
+//
+// The converse direction is deliberately NOT asserted.  Aliases are a feature
+// here: oper_key_map maps several spellings onto one kind (the FloatingPoint
+// leniency described in CLAUDE.md, "-" for both negation and subtraction), so
+// requiring symbol -> kind -> same symbol would fail on correct code.  Only the
+// direction that makes a dump unreadable is a defect.
+
+#include "somtparser/frontend/parser.h"
+
+#include <iostream>
+#include <utility>
+#include <string>
+#include <vector>
+
+#include "test_helpers.h"
+
+using namespace SOMTParser;
+
+namespace {
+
+// Kinds that deliberately print a symbol oper_key_map resolves to a *different*
+// kind.  A shared symbol is only acceptable when the parser can recover the
+// right kind from the term itself; each entry below records how, and each was
+// checked by building the term, dumping it, re-parsing, and confirming the kind
+// came back unchanged.  NT_STR_INDEXOF_REG is deliberately absent: it shared
+// "str.indexof" with an operator of a different arity, so nothing could have
+// recovered it, and the dump was unreadable.
+const std::vector<std::pair<NODE_KIND, const char*>> kSharedByDesign = {
+    // "-" is SMT-LIB's own overload.  Recovered by arity: one argument is
+    // negation, two or more is subtraction.  Verified: (- x) round-trips as
+    // NT_NEG and (- x y) as NT_SUB.
+    {NODE_KIND::NT_NEG, "arity: 1 argument is negation, 2+ is subtraction"},
+
+    // Sort-specialised variants of = and distinct.  The parser never builds
+    // them -- (= a b) on Bool parses to NT_EQ, not NT_EQ_BOOL -- so they are
+    // produced only internally (conv_parser's binarisation lists them) and
+    // recovered by re-deriving from the operands' sorts.
+    {NODE_KIND::NT_EQ_BOOL, "sort-specialised; parser builds plain NT_EQ and re-derives"},
+    {NODE_KIND::NT_EQ_OTHER, "sort-specialised; parser builds plain NT_EQ and re-derives"},
+    {NODE_KIND::NT_DISTINCT_BOOL, "sort-specialised; parser builds plain NT_DISTINCT"},
+    {NODE_KIND::NT_DISTINCT_OTHER, "sort-specialised; parser builds plain NT_DISTINCT"},
+};
+
+bool isSharedSymbolByDesign(NODE_KIND k) {
+    for (const auto& entry : kSharedByDesign) {
+        if (entry.first == k) { return true; }
+    }
+    return false;
+}
+
+}  // namespace
+
+int main() {
+    std::cout << "======= kindToString / oper_key_map agreement =======\n";
+
+    // oper_key_map lives on the parser; go through one rather than duplicating
+    // the table here, so this test tracks the real lookup the parser performs.
+    auto parser = std::make_shared<Parser>();
+
+    struct Mismatch {
+        std::string symbol;
+        std::size_t printed_by;
+        std::size_t resolves_to;
+    };
+    std::vector<Mismatch> mismatches;
+    std::size_t checked = 0;
+    std::size_t allowed = 0;
+
+    for (std::size_t i = 0; i < NUM_KINDS; ++i) {
+        const auto kind = static_cast<NODE_KIND>(i);
+        const std::string printed = kindToString(kind);
+        if (printed.empty()) { continue; }
+
+        const auto it = oper_key_map.find(printed);
+        if (it == oper_key_map.end()) {
+            // Not an operator symbol at all (NT_CONST, NT_VAR, internal kinds).
+            // Those print a descriptive name and are never parsed back.
+            continue;
+        }
+
+        ++checked;
+        if (it->second != kind) {
+            if (isSharedSymbolByDesign(kind)) { ++allowed; continue; }
+            mismatches.push_back({printed, i, static_cast<std::size_t>(it->second)});
+        }
+    }
+
+    // Every entry in the allow-list must still be a collision.  Without this,
+    // fixing one of them would leave a stale exemption that silently forgives
+    // a future regression on the same symbol.
+    VERIFY(allowed == kSharedByDesign.size());
+
+    for (const auto& m : mismatches) {
+        std::cerr << "  FAIL kind #" << m.printed_by << " prints as \"" << m.symbol
+                  << "\", which the parser resolves to kind #" << m.resolves_to << "\n";
+    }
+
+    std::cout << checked << " operator kind(s) checked, " << mismatches.size() << " mismatched\n";
+    VERIFY(mismatches.empty());
+    // A table lookup that silently stopped matching anything would leave
+    // mismatches empty; require the property to have been exercised.
+    VERIFY(checked >= 100);
+
+    std::cout << "Every operator kind prints a symbol that resolves back to it.\n";
+    return 0;
+}

--- a/test/regression/test_order_key_print_stable.cpp
+++ b/test/regression/test_order_key_print_stable.cpp
@@ -1,0 +1,99 @@
+// The key that canonicalises commutative operand order must depend only on how
+// an operand prints.
+//
+// It used to be DAGNode::hashCode(), which also mixes in the sort string and
+// the internal name/child layout. Neither survives a dump: a Real literal
+// prints as `0` and reads back as IntOrReal, and an fp literal built by
+// ((_ to_fp 11 53) RNE 1.0) is a childless node whose name is the whole
+// literal, while the same text read back as (fp #b0 ...) is a three-child node
+// named "(fp_bit_representation)". Ordering by hashCode() therefore gave one
+// script two different operand orders on consecutive parses, and dumpSMT2()
+// never reached a fixed point.
+//
+// test_dump_roundtrip_instances.cpp catches that end to end, but only for terms
+// the corpus happens to contain, and only as an opaque "line N differs". This
+// file pins the underlying invariant directly, on the two representation splits
+// that actually caused it: nodes that print alike must key alike, whatever they
+// look like inside.
+
+#include "somtparser/frontend/parser.h"
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "test_helpers.h"
+
+using namespace SOMTParser;
+
+namespace {
+
+// Parses `script` and returns the operand of the single top-level assertion's
+// binary root that prints as `wanted`.
+std::shared_ptr<DAGNode> operandPrintingAs(const std::string& script, const std::string& wanted) {
+    auto parser = std::make_shared<Parser>();
+    VERIFY(parser->parseStr(script));
+    const auto assertions = parser->getAssertions();
+    VERIFY(assertions.size() == 1);
+    for (const auto& child : assertions[0]->getChildren()) {
+        if (dumpSMTLIB2(child) == wanted) return child;
+    }
+    std::cerr << "  no operand printed as " << wanted << "; assertion was "
+              << dumpSMTLIB2(assertions[0]) << "\n";
+    VERIFY(false);
+    return nullptr;
+}
+
+void check(const char* what, const std::shared_ptr<DAGNode>& a, const std::shared_ptr<DAGNode>& b) {
+    // Guard the premise: if these ever stop printing alike the test below would
+    // pass for the wrong reason.
+    VERIFY(dumpSMTLIB2(a) == dumpSMTLIB2(b));
+    std::cout << "  " << what << ": both print as " << dumpSMTLIB2(a) << "\n";
+    if (a->orderKey() != b->orderKey()) {
+        std::cerr << "  order keys differ: " << a->orderKey() << " vs " << b->orderKey() << "\n";
+        VERIFY(false);
+    }
+    std::cout << "    same order key, despite sort " << a->getSort()->toString() << " vs "
+              << b->getSort()->toString() << " and " << a->getChildrenSize() << " vs "
+              << b->getChildrenSize() << " children\n";
+}
+
+}  // namespace
+
+int main() {
+    std::cout << "======= commutative order key depends only on printed form =======\n";
+
+    // A Real literal and the Int-or-Real literal its printed form reads back as.
+    {
+        const std::string decl = "(set-logic ALL)(declare-const zero2 Real)";
+        auto written = operandPrintingAs(decl + "(assert (= zero2 0.00000))", "0");
+        auto reread = operandPrintingAs(decl + "(assert (= zero2 0))", "0");
+        // The premise of the whole bug: these really are different nodes.
+        VERIFY(written->getSort()->toString() != reread->getSort()->toString());
+        check("real zero", written, reread);
+    }
+
+    // An fp literal built by to_fp, and the same text read back as (fp ...).
+    {
+        const std::string decl = "(set-logic ALL)(declare-const x (_ FloatingPoint 11 53))";
+        const std::string triple =
+            "(fp #b0 #b01111111111 #b0000000000000000000000000000000000000000000000000000)";
+        auto folded = operandPrintingAs(decl + "(assert (fp.eq x ((_ to_fp 11 53) RNE 1.0)))", triple);
+        auto reread = operandPrintingAs(decl + "(assert (fp.eq x " + triple + "))", triple);
+        VERIFY(folded->getChildrenSize() != reread->getChildrenSize());
+        check("fp one", folded, reread);
+    }
+
+    // Sanity: the key is not simply constant, or everything above would pass
+    // no matter what the key did.
+    {
+        const std::string decl = "(set-logic ALL)(declare-const p Int)(declare-const q Int)";
+        auto p = operandPrintingAs(decl + "(assert (= p q))", "p");
+        auto q = operandPrintingAs(decl + "(assert (= p q))", "q");
+        VERIFY(p->orderKey() != q->orderKey());
+        std::cout << "  distinct terms still key apart\n";
+    }
+
+    std::cout << "Order key depends only on the printed form.\n";
+    return 0;
+}

--- a/test/regression/test_order_key_print_stable.cpp
+++ b/test/regression/test_order_key_print_stable.cpp
@@ -84,6 +84,25 @@ int main() {
         check("fp one", folded, reread);
     }
 
+    // The checks above pin orderKey() itself. This one pins that the operand
+    // ordering actually uses it: a commutative operator over operands that
+    // print alike must lay them out the same way in both scripts. Reverting
+    // sortParams to hashCode() leaves every check above passing and fails here.
+    {
+        auto real_zero = std::make_shared<Parser>();
+        VERIFY(real_zero->parseStr("(set-logic ALL)(declare-const zero2 Real)(assert (= zero2 0.00000))"));
+        auto int_zero = std::make_shared<Parser>();
+        VERIFY(int_zero->parseStr("(set-logic ALL)(declare-const zero2 Real)(assert (= zero2 0))"));
+        const std::string a = dumpSMTLIB2(real_zero->getAssertions()[0]);
+        const std::string b = dumpSMTLIB2(int_zero->getAssertions()[0]);
+        if (a != b) {
+            std::cerr << "  commutative order not stable across representations:\n"
+                      << "    " << a << "\n    " << b << "\n";
+            VERIFY(false);
+        }
+        std::cout << "  equal-printing operands order alike: " << a << "\n";
+    }
+
     // Sanity: the key is not simply constant, or everything above would pass
     // no matter what the key did.
     {


### PR DESCRIPTION
`dumpSMT2()` could emit scripts this parser rejects. Three defects of one shape — **a
construct that can be built and not read back** — plus the property test that finds that
class rather than the instances of it anyone thought to write down.

## The defects

**`str.indexof_re` printed as `str.indexof`.** They are different operators:
`str.indexof` takes a string needle and a start offset (three arguments),
`str.indexof_re` takes a regular expression and no offset (two). So every term containing
`str.indexof_re` dumped to a script this parser rejects on arity —
`test/instances/eval_dispatch_qf_s.smt2` does exactly that.

The one-line fix is not the interesting part. No per-operator test can find this class:
printing is correct in isolation for every operator anyone remembered to check, and the
defect is a *relationship* between two tables that nothing compared. So the fix adds the
comparison as a property over the whole table — for every kind whose printed name is a
known operator symbol, that symbol must resolve back to that kind. 197 operator kinds are
covered by one assertion.

**`(define-funs-rec ...)` groups were dumped as separate commands.** Each member is an
ordinary `NT_FUNC_REC` node once parsed and nothing recorded that it was declared jointly,
so the printer could not tell a mutually recursive group from a set of independent
recursive functions. Fine for a group of one, wrong for every larger one: the members call
each other, so the first command emitted refers to a function the script has not defined
yet. `test/instances/functions.smt2` dumped `is-even` calling an `is-odd` that did not
exist yet.

**Commutative operands were ordered by `hashCode()`.** That key is derived from the term's
content, so it is reproducible across runs — but it mixes in the node's sort string, its
internal name and its child count, and none of those survive a dump. Two splits in the
corpus: a Real literal written `0.00000` prints as `0` and reads back with sort
`IntOrReal`; and `((_ to_fp 11 53) RNE 1.0)` folds to a childless `NT_CONST` whose name is
the whole `(fp #b0 ...)` literal, while that same printed text reads back as a three-child
node. Same term, different key, different operand order on the second parse. Ordering now
uses the printed form, which is by construction the thing that survives.

## The test that found them

`test_dump_reparse.cpp` already asserted the right property — dump, re-read, dump again,
compare — but every one of its cases was hand-written, and its own header says they
"deliberately avoid operators whose printing is fixed elsewhere". A hand-written case can
only contain a construct somebody thought to write down; the defect this property exists to
catch is precisely the one nobody thinks to write down.

So `test_dump_roundtrip_instances.cpp` supplies the **corpus** instead of the assertion,
running the same property over every `.smt2` under `test/instances`. All three defects
above came out of it. Adding an instance extends the check for free.

`test_order_key_print_stable.cpp` gains the composed case: checking `orderKey()` in
isolation left the test passing while the corpus round trip broke, so it now also asserts
that a term whose operands print alike lays them out alike whichever representation the
parser built — which is the property the ordering exists to provide.

## Verification

`43/43` C++ tests, clean configure and build from `origin/main`.

Independent of #49: different files, same base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)