### PR TITLE
fix(parse): `(_ divisible n)` is the operator SMT-LIB defines

### DIFF
--- a/include/somtparser/core/kind.h
+++ b/include/somtparser/core/kind.h
@@ -281,6 +281,16 @@ namespace SOMTParser{
         {"to_real", NODE_KIND::NT_TO_REAL},
         {"to_int", NODE_KIND::NT_TO_INT},
         {"is_int", NODE_KIND::NT_IS_INT},
+        // `((_ divisible n) t)` is the STANDARD spelling (SMT-LIB 2.6, theory
+        // Ints: "((_ divisible n) Int Bool) for all n in N>0"). The engine knew
+        // only `is_divisible`, which is not an SMT-LIB name at all, so a
+        // conforming script could not be read and a term containing one could
+        // not be written for any other solver to read.
+        {"divisible", NODE_KIND::NT_IS_DIVISIBLE},
+        // Kept as a lenient alias, in the flat two-argument form the engine has
+        // always accepted. Parser leniency is deliberate here (CLAUDE.md), and
+        // dropping a spelling that used to work would break input this project
+        // has produced itself.
         {"is_divisible", NODE_KIND::NT_IS_DIVISIBLE},
         {"is_prime", NODE_KIND::NT_IS_PRIME},
         {"is_even", NODE_KIND::NT_IS_EVEN},

--- a/src/core/kind.cpp
+++ b/src/core/kind.cpp
@@ -192,7 +192,9 @@ namespace SOMTParser{
         case NODE_KIND::NT_IS_INT:
             return "is_int";
         case NODE_KIND::NT_IS_DIVISIBLE:
-            return "is_divisible";
+            // The standard name, so a dumped script is readable by another
+            // solver. `is_divisible` remains accepted on input.
+            return "divisible";
         case NODE_KIND::NT_IS_PRIME:
             return "is_prime";
         case NODE_KIND::NT_IS_EVEN:

--- a/src/frontend/expr_parser.cpp
+++ b/src/frontend/expr_parser.cpp
@@ -1064,7 +1064,18 @@ namespace SOMTParser{
 				condAssert(oper_params.size() == 1, "Invalid number of parameters for is_int");
 				return mkIsInt(oper_params[0]);
 			case NODE_KIND::NT_IS_DIVISIBLE:
-				condAssert(oper_params.size() == 2, "Invalid number of parameters for is_divisible");
+				// ((_ divisible n) t) -- the standard form, where n is an INDEX
+				// and arrives in func_args rather than as an argument. Same
+				// shape as nat2bv above, and the same defect: without this the
+				// two-parameter assert aborted on every conforming script.
+				//
+				// The children stay (term, n) either way, so the flat form and
+				// the indexed one build the identical node and nothing
+				// downstream has to know which was written.
+				if(func_args.size() == 1 && oper_params.size() == 1){
+					return mkIsDivisible(oper_params[0], func_args[0]);
+				}
+				condAssert(oper_params.size() == 2, "Invalid number of parameters for divisible");
 				return mkIsDivisible(oper_params[0], oper_params[1]);
 			case NODE_KIND::NT_IS_PRIME:
 				condAssert(oper_params.size() == 1, "Invalid number of parameters for is_prime");

--- a/src/ir/dag.cpp
+++ b/src/ir/dag.cpp
@@ -474,7 +474,12 @@ namespace SOMTParser{
             // the generic path and printed as (int2bv x 8) instead of
             // ((_ int2bv 8) x).  Ported from the SMTStabilizer fork.
             case NODE_KIND::NT_INT_TO_BV:
-            case NODE_KIND::NT_NAT_TO_BV: {
+            case NODE_KIND::NT_NAT_TO_BV:
+            // divisible is indexed for the same reason and was missing for the
+            // same reason: it printed as (divisible x 3), which is not the
+            // operator SMT-LIB defines and which this parser would read back as
+            // a two-argument application.
+            case NODE_KIND::NT_IS_DIVISIBLE: {
                 auto child0 = node->getChild(0).get();
                 auto child1 = node->getChild(1).get();
 

--- a/test/regression/test_divisible_indexed.cpp
+++ b/test/regression/test_divisible_indexed.cpp
@@ -1,0 +1,129 @@
+// `((_ divisible n) t)` is the operator SMT-LIB defines; `is_divisible` is not.
+//
+// SMT-LIB 2.6, theory Ints, declares
+//
+//     ((_ divisible n) Int Bool)   for all n in N>0
+//
+// -- an INDEXED operator taking one argument, where n is part of the operator
+// rather than an operand. This engine had only a flat two-argument
+// `(is_divisible t n)`, under a name the standard does not define, so:
+//
+//   * a conforming script could not be READ. `((_ divisible 3) x)` reached the
+//     two-parameter assert with one parameter and aborted.
+//   * a term containing one could not be WRITTEN for anything else to read. It
+//     dumped as `(is_divisible x 3)`, which no other solver accepts -- and
+//     which, once the standard spelling was added, this parser would itself
+//     read back as an application of a two-argument function.
+//
+// Both spellings are still accepted on input: leniency is deliberate here, and
+// a script this project has already produced must keep parsing. Only the OUTPUT
+// is now the standard one, because output is what another tool has to read.
+
+#include "somtparser/parser.h"
+
+#include <iostream>
+#include <string>
+
+#include "test_helpers.h"
+
+using namespace SOMTParser;
+
+namespace {
+
+bool has(const std::string& hay, const std::string& needle) {
+    return hay.find(needle) != std::string::npos;
+}
+
+/** Parse, requiring success, and return the script as the engine prints it. */
+std::string dump(const std::string& script, const char* what) {
+    ParserPtr p = newParser();
+    if (!p->parseStr(script)) {
+        std::cout << "  failed to parse (" << what << "):\n" << script;
+        VERIFY(false);
+    }
+    return p->dumpSMT2();
+}
+
+const char* kDecl = "(set-logic ALL)\n(declare-const x Int)\n";
+
+} // namespace
+
+int main() {
+    std::cout << "======= (_ divisible n) =======\n";
+
+    // ---- The standard form parses. -----------------------------------------
+    const std::string out =
+        dump(std::string(kDecl) + "(assert ((_ divisible 3) x))\n(check-sat)\n",
+             "indexed form");
+    VERIFY(has(out, "((_ divisible 3) x)"));
+
+    // ---- The flat form still parses, and prints as the standard one. --------
+    //
+    // Not merely "still accepted": the two spellings must build the SAME term.
+    // If they did not, a script written one way and a script written the other
+    // would be different problems while looking like the same one.
+    const std::string flat =
+        dump(std::string(kDecl) + "(assert (is_divisible x 3))\n(check-sat)\n",
+             "flat form");
+    VERIFY(has(flat, "((_ divisible 3) x)"));
+    VERIFY(flat == out);
+
+    // ---- What the dump says must be readable back. -------------------------
+    //
+    // This is the half that was broken in the direction nobody looks: the old
+    // output named an operator that, after this change, resolves to the indexed
+    // one and would arrive with the wrong argument count.
+    {
+        ParserPtr again = newParser();
+        VERIFY(again->parseStr(out));
+        VERIFY(again->dumpSMT2() == out);
+    }
+
+    // ---- The index is not an argument. -------------------------------------
+    {
+        // `(divisible x 3)` -- the standard name in the FLAT shape -- is
+        // accepted by the same leniency that keeps `is_divisible` working, and
+        // must build the same term rather than a different two-argument one.
+        const std::string mixed =
+            dump(std::string(kDecl) + "(assert (divisible x 3))\n(check-sat)\n",
+                 "standard name, flat shape");
+        VERIFY(mixed == out);
+    }
+    {
+        // A VARIABLE divisor. SMT-LIB has no such operator -- an index is a
+        // numeral -- but this engine has always had one in the flat form, where
+        // mkIsDivisible checks only that both arguments are Int. What matters
+        // is that the extension did not fork: the indexed spelling and the flat
+        // one build the same node, so a script written either way asks the same
+        // question. The alternative -- accepting both and meaning two different
+        // things -- is the failure this whole change is about.
+        const std::string decls = "(set-logic ALL)\n(declare-const x Int)\n"
+                                  "(declare-const y Int)\n";
+        const std::string a = dump(decls + "(assert ((_ divisible y) x))\n(check-sat)\n",
+                                   "variable divisor, indexed shape");
+        const std::string b = dump(decls + "(assert (is_divisible x y))\n(check-sat)\n",
+                                   "variable divisor, flat shape");
+        VERIFY(a == b);
+        // And it still reads back, which is the property that stops the
+        // extension from becoming unwritable now that the printer emits the
+        // indexed shape for it.
+        ParserPtr again = newParser();
+        VERIFY(again->parseStr(a));
+        VERIFY(again->dumpSMT2() == a);
+    }
+
+    // ---- Distinct divisors stay distinct. ----------------------------------
+    {
+        // Hash-consing interns structurally equal terms, and the index is part
+        // of the structure. If it were dropped on the way in, these two would
+        // become one node and one of the two constraints would vanish.
+        const std::string two =
+            dump(std::string(kDecl) + "(assert ((_ divisible 3) x))\n"
+                 "(assert ((_ divisible 5) x))\n(check-sat)\n", "two divisors");
+        VERIFY(has(two, "((_ divisible 3) x)"));
+        VERIFY(has(two, "((_ divisible 5) x)"));
+    }
+
+    std::cout << "All divisible tests passed." << std::endl;
+    return 0;
+}


### PR DESCRIPTION
SMT-LIB 2.6, theory Ints, declares

```
((_ divisible n) Int Bool)   for all n in N>0
```

an **indexed** operator taking one argument, where `n` is part of the operator rather than an operand. This engine had only a flat two-argument `(is_divisible t n)`, under a name the standard does not define anywhere — so both directions were broken:

- **A conforming script could not be read.** `((_ divisible 3) x)` reached the two-parameter assert holding one parameter and aborted, surfacing as `Unknown or unexpected symbol "divisible"`.
- **A term containing one could not be written for anything else to read.** It dumped as `(is_divisible x 3)`, which no other solver accepts.

`nat2bv` and `int2bv` had the identical defect and were fixed earlier in both the parse and print paths — the comments there describe this exact shape. `divisible` was left out of both, which is how it survived.

### What does not change

Input leniency. `is_divisible` and the flat two-argument form still parse, and both spellings build the *same node*, so a script written either way asks the same question. Only the output moves to the standard spelling, because output is what another tool has to read.

The variable-divisor extension the flat form has always allowed is left alone and is now pinned by a test.

### Testing

`test/regression/test_divisible_indexed.cpp`. Full suite: 49/49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)