### PR TITLE
fix(parse): `<`, `<=`, `>` and `>=` are chainable

### DIFF
--- a/src/frontend/expr_parser.cpp
+++ b/src/frontend/expr_parser.cpp
@@ -586,18 +586,23 @@ namespace SOMTParser{
                             res = mkSub(frame.oper_params);
                         } else if (opName == "*") {
                             res = mkMul(frame.oper_params);
+                        // :chainable, like `=` and `distinct` beside them --
+                        // `(<= a b c)` means `(and (<= a b) (<= b c))`, and the
+                        // n-ary builders do that expansion. This is the SECOND
+                        // dispatch for the same operators (parseOper has the
+                        // other), which is why the two disagreed for so long.
                         } else if (opName == "<=") {
-                            condAssert(frame.oper_params.size() == 2, "Invalid number of parameters for <=");
-                            res = mkLe(frame.oper_params[0], frame.oper_params[1]);
+                            condAssert(frame.oper_params.size() >= 2, "Not enough parameters for <=");
+                            res = mkLe(frame.oper_params);
                         } else if (opName == "<") {
-                            condAssert(frame.oper_params.size() == 2, "Invalid number of parameters for <");
-                            res = mkLt(frame.oper_params[0], frame.oper_params[1]);
+                            condAssert(frame.oper_params.size() >= 2, "Not enough parameters for <");
+                            res = mkLt(frame.oper_params);
                         } else if (opName == ">=") {
-                            condAssert(frame.oper_params.size() == 2, "Invalid number of parameters for >=");
-                            res = mkGe(frame.oper_params[0], frame.oper_params[1]);
+                            condAssert(frame.oper_params.size() >= 2, "Not enough parameters for >=");
+                            res = mkGe(frame.oper_params);
                         } else if (opName == ">") {
-                            condAssert(frame.oper_params.size() == 2, "Invalid number of parameters for >");
-                            res = mkGt(frame.oper_params[0], frame.oper_params[1]);
+                            condAssert(frame.oper_params.size() >= 2, "Not enough parameters for >");
+                            res = mkGt(frame.oper_params);
                         } else if(opName == "bvult"){
                             condAssert(frame.oper_params.size() == 2, "Invalid number of parameters for bvult");
                             res = mkBvUlt(frame.oper_params[0], frame.oper_params[1]);
@@ -1042,18 +1047,25 @@ namespace SOMTParser{
             case NODE_KIND::NT_CSCH:
                 condAssert(oper_params.size() == 1, "Invalid number of parameters for csch");
                 return mkCsch(oper_params[0]);
+            // The four orderings are :chainable (SMT-LIB 2.6, theory Ints and
+			// Reals): `(<= a b c)` is legal and means `(and (<= a b) (<= b c))`.
+			// The n-ary builders below have always done exactly that expansion
+			// -- and nothing called them, because this dispatch asserted two
+			// parameters, so a conforming script aborted here instead. `=` and
+			// `distinct`, which are chainable and pairwise in the same way,
+			// were wired to their n-ary forms from the first.
             case NODE_KIND::NT_LE:
-				condAssert(oper_params.size() == 2, "Invalid number of parameters for <= ");
-				return mkLe(oper_params[0], oper_params[1]);
+				condAssert(oper_params.size() >= 2, "Not enough parameters for <=");
+				return mkLe(oper_params);
 			case NODE_KIND::NT_LT:
-				condAssert(oper_params.size() == 2, "Invalid number of parameters for <");
-				return mkLt(oper_params[0], oper_params[1]);
+				condAssert(oper_params.size() >= 2, "Not enough parameters for <");
+				return mkLt(oper_params);
 			case NODE_KIND::NT_GE:
-				condAssert(oper_params.size() == 2, "Invalid number of parameters for >= ");
-				return mkGe(oper_params[0], oper_params[1]);
+				condAssert(oper_params.size() >= 2, "Not enough parameters for >=");
+				return mkGe(oper_params);
 			case NODE_KIND::NT_GT:
-				condAssert(oper_params.size() == 2, "Invalid number of parameters for >");
-				return mkGt(oper_params[0], oper_params[1]);
+				condAssert(oper_params.size() >= 2, "Not enough parameters for >");
+				return mkGt(oper_params);
 			case NODE_KIND::NT_TO_REAL:
 				condAssert(oper_params.size() == 1, "Invalid number of parameters for to_real");
 				return mkToReal(oper_params[0]);

--- a/src/frontend/op_parser.cpp
+++ b/src/frontend/op_parser.cpp
@@ -5025,10 +5025,6 @@ namespace SOMTParser{
             case NODE_KIND::NT_MOD:
             case NODE_KIND::NT_LOG:
             case NODE_KIND::NT_ATAN2:
-            case NODE_KIND::NT_LE:
-            case NODE_KIND::NT_LT:
-            case NODE_KIND::NT_GE:
-            case NODE_KIND::NT_GT:
             case NODE_KIND::NT_IS_DIVISIBLE:
             case NODE_KIND::NT_GCD:
             case NODE_KIND::NT_LCM:
@@ -5118,6 +5114,15 @@ namespace SOMTParser{
                 return 4;
 
             // n-ary
+            // The four orderings are :chainable, exactly as `=` and `distinct`
+            // are, so `(<= a b c)` has the arity of the list it is given. They
+            // sat in the `binary` group above, which made a conforming script a
+            // parse failure -- and the n-ary builders that expand the chain
+            // were unreachable.
+            case NODE_KIND::NT_LE:
+            case NODE_KIND::NT_LT:
+            case NODE_KIND::NT_GE:
+            case NODE_KIND::NT_GT:
             case NODE_KIND::NT_EQ:
             case NODE_KIND::NT_EQ_BOOL:
             case NODE_KIND::NT_EQ_OTHER:

--- a/test/regression/test_chainable_comparisons.cpp
+++ b/test/regression/test_chainable_comparisons.cpp
@@ -1,0 +1,123 @@
+// `(<= a b c)` is legal SMT-LIB and this parser could not read it.
+//
+// SMT-LIB 2.6 declares `<`, `<=`, `>` and `>=` with the `:chainable`
+// attribute, exactly as it declares `=`: an application with three or more
+// arguments means the conjunction of ADJACENT pairs, so
+//
+//     (<= a b c)   is   (and (<= a b) (<= b c))
+//
+// The n-ary builders that do that expansion have been in op_parser.cpp from the
+// first -- `mkLe(const std::vector<...>&)` and its three siblings -- and
+// nothing called them. Both dispatches asserted exactly two parameters, so a
+// conforming script was a PARSE FAILURE with no message at all: condAssert
+// throws, parseStr catches, and the caller sees `false`.
+//
+// Two dispatches, because there are two: the frame-based loop in the iterative
+// expression parser and `parseOper`. They disagreed with each other and with
+// the builders, which is how three copies of one operator's arity drifted
+// apart. `getArity`'s table said `binary` too -- a fourth copy, and dead code
+// with no callers, fixed here so it does not mislead whoever wires it up.
+//
+// Adjacent pairs matter, and so does ORDER. These are not commutative: reading
+// `(< a b c)` as all-pairs would add `(< a c)`, which is implied and so is
+// merely redundant, but reordering the operands would produce a different
+// constraint entirely.
+
+#include "somtparser/parser.h"
+
+#include <iostream>
+#include <string>
+
+#include "test_helpers.h"
+
+using namespace SOMTParser;
+
+namespace {
+
+bool has(const std::string& hay, const std::string& needle) {
+    return hay.find(needle) != std::string::npos;
+}
+
+const char* kDecl = "(set-logic ALL)\n(declare-const a Int)\n(declare-const b Int)\n"
+                    "(declare-const c Int)\n(declare-const d Int)\n";
+
+std::string dump(const std::string& assertion, const char* what) {
+    ParserPtr p = newParser();
+    const std::string s = std::string(kDecl) + "(assert " + assertion + ")\n(check-sat)\n";
+    if (!p->parseStr(s)) {
+        std::cout << "  failed to parse (" << what << "): " << assertion << "\n";
+        VERIFY(false);
+    }
+    return p->dumpSMT2();
+}
+
+} // namespace
+
+int main() {
+    std::cout << "======= chainable comparisons =======\n";
+
+    // ---- Three and four arguments, all four orderings. ---------------------
+    VERIFY(has(dump("(<= a b c)", "<="), "(and (<= a b) (<= b c))"));
+    VERIFY(has(dump("(< a b c)", "<"), "(and (< a b) (< b c))"));
+    VERIFY(has(dump("(>= a b c)", ">="), "(and (>= a b) (>= b c))"));
+    VERIFY(has(dump("(> a b c)", ">"), "(and (> a b) (> b c))"));
+    VERIFY(has(dump("(< a b c d)", "< four"), "(and (< a b) (< b c) (< c d))"));
+
+    // ---- The order of the operands is preserved. ----------------------------
+    {
+        // The property that makes this an expansion rather than a rewrite.
+        // `(< a b c)` and `(< c b a)` are different constraints, and a chain
+        // built from a canonicalised operand list would confuse them -- which
+        // is a risk for these and not for `=`, because `=` is symmetric.
+        const std::string up = dump("(< a b c)", "ascending");
+        const std::string down = dump("(< c b a)", "descending");
+        VERIFY(has(up, "(< a b)") && has(up, "(< b c)"));
+        VERIFY(has(down, "(< c b)") && has(down, "(< b a)"));
+        VERIFY(up != down);
+    }
+
+    // ---- Two arguments are unchanged. --------------------------------------
+    {
+        // The binary case must not grow an `and` around it: every existing
+        // script is this case, and a wrapper would change the shape of every
+        // term in the corpus.
+        const std::string s = dump("(<= a b)", "binary");
+        VERIFY(has(s, "(assert (<= a b))"));
+    }
+
+    // ---- One argument is still an error. ------------------------------------
+    {
+        ParserPtr p = newParser();
+        VERIFY(!p->parseStr(std::string(kDecl) + "(assert (<= a))\n(check-sat)\n"));
+    }
+
+    // ---- What it emits, it reads back. -------------------------------------
+    {
+        const std::string out = dump("(< a b c d)", "round trip");
+        ParserPtr again = newParser();
+        VERIFY(again->parseStr(out));
+        VERIFY(again->dumpSMT2() == out);
+    }
+
+    // ---- Mixed with the two that already worked. ---------------------------
+    {
+        // `=` and `distinct` were wired to their n-ary forms from the first, so
+        // this checks the four new ones compose with them rather than only
+        // working alone.
+        const std::string s = dump("(and (<= a b c) (= a b c) (distinct c d))", "mixed");
+        VERIFY(has(s, "(<= a b)"));
+        ParserPtr p = newParser();
+        VERIFY(p->parseStr(s));
+    }
+    {
+        // Reals, and a mixed Int/Real chain -- the numeric leniency the rest of
+        // the parser depends on applies to the expanded pairs too.
+        ParserPtr p = newParser();
+        VERIFY(p->parseStr("(set-logic ALL)\n(declare-const r Real)\n"
+                           "(declare-const s Real)\n(declare-const i Int)\n"
+                           "(assert (<= r s 3.5))\n(assert (< i r 9))\n(check-sat)\n"));
+    }
+
+    std::cout << "All chainable-comparison tests passed." << std::endl;
+    return 0;
+}


### PR DESCRIPTION
SMT-LIB 2.6 declares `<`, `<=`, `>` and `>=` with the **`:chainable`** attribute, exactly as it declares `=`: an application with three or more arguments means the conjunction of *adjacent* pairs.

```smt2
(assert (<= a b c))     ; means (and (<= a b) (<= b c))
```

This parser could not read one, and failed with **no message at all** — `condAssert` throws, `parseStr` catches, and the caller sees `false`.

### What was already there

The n-ary builders that perform exactly this expansion have been in `op_parser.cpp` from the first — `mkLe(const std::vector<...>&)` and its three siblings. Nothing called them. One operator's arity was written down in four places and they disagreed:

| | said |
|---|---|
| the frame-based dispatch in the iterative expression parser | binary |
| `parseOper`'s dispatch | binary |
| `mkLe(vector)` and its three siblings | **n-ary** |
| `getArity`'s table | binary |

All four now say chainable. `getArity` has no callers and is dead code; it is corrected anyway so it does not mislead whoever wires it up.

### What is deliberately unchanged

**Operand order is preserved**, which is what makes this an expansion rather than a rewrite. These are not commutative: `(< a b c)` and `(< c b a)` are different constraints, and a chain built from a canonicalised operand list would confuse them — a risk here and not for `=`, which is symmetric.

**The binary case is untouched.** Wrapping it in an `and` would change the shape of every term in every existing script.

### Testing

`test/regression/test_chainable_comparisons.cpp` — three and four arguments across all four orderings, order preservation, the binary case unchanged, one argument still an error, the output reading back, and composition with `=` and `distinct`.

Over **224 SMT-LIB benchmarks** the accepted set is unchanged except for one that now parses and did not: it asserts `(<= y x (+ y 1))`. Full suite: 51/51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
