### PR TITLE
fix(dump): a group of mutually recursive datatypes is one command

### DIFF
--- a/src/frontend/base_parser.cpp
+++ b/src/frontend/base_parser.cpp
@@ -3629,19 +3629,35 @@ namespace SOMTParser{
 				if(i == sort_map.end() || !i->second) return nullptr;
 				return &i->second->getDtConstructors();
 			};
-			// A -> B when a selector of A has sort B. Collected by NAME, since
-			// a placeholder sort and the finished one are different objects.
+			// A -> B when a selector of A MENTIONS B anywhere in its sort.
+			// Collected by NAME, since a placeholder sort and the finished one
+			// are different objects.
+			//
+			// Anywhere, not just at the top: a selector of sort
+			// `(Array Int TL)` depends on TL exactly as one of sort `TL` does,
+			// and reading only the outermost name missed the edge. The two
+			// datatypes then landed in different groups, were emitted as
+			// separate commands, and the second was named before it was
+			// declared -- which is the very defect this grouping exists to fix,
+			// reached through a sort constructor instead of directly.
 			std::unordered_map<std::string, std::unordered_set<std::string>> deps;
 			std::unordered_set<std::string> is_dt(datatype_order.begin(),
 			                                      datatype_order.end());
+			std::function<void(const std::shared_ptr<Sort>&, const std::string&)>
+				mentions = [&](const std::shared_ptr<Sort>& s,
+				               const std::string& owner){
+					if(!s) return;
+					if(s->name != owner && is_dt.count(s->name)){
+						deps[owner].insert(s->name);
+					}
+					for(const auto& ch : s->children){ mentions(ch, owner); }
+				};
 			for(const auto& n : datatype_order){
 				const auto* cs = ctors_of(n);
 				if(!cs) continue;
 				for(const auto& c : *cs){
 					for(const auto& sel : c.selectors){
-						if(!sel.sort) continue;
-						const std::string& t = sel.sort->name;
-						if(t != n && is_dt.count(t)) deps[n].insert(t);
+						mentions(sel.sort, n);
 					}
 				}
 			}

--- a/src/frontend/base_parser.cpp
+++ b/src/frontend/base_parser.cpp
@@ -3592,6 +3592,9 @@ namespace SOMTParser{
 		// declares all of them, so emitting a declare-fun for each as well
 		// would make the dump reject itself as a redeclaration.
 		std::unordered_set<std::string> datatype_member_names;
+		// Datatype sorts in declaration order; emitted in dependency groups
+		// after this loop, because a group cannot be split.
+		std::vector<std::string> datatype_order;
 		for(const auto& sort_name : getSymbolManager()->getSortOrder()){
 			auto it = sort_map.find(sort_name);
 			if(it == sort_map.end() || !it->second) continue;
@@ -3600,25 +3603,131 @@ namespace SOMTParser{
 				ss << "(declare-sort " << sort_name << " " << sort->arity << ")" << std::endl;
 			}
 			else if(sort->isDatatype() && sort->hasDtConstructors()){
-				// (declare-datatypes ((T 0)) (((ctor (sel S) ...) ...)))
-				// Without this the constructors were dumped as plain
-				// declare-funs over a sort that was never declared, so no
-				// datatype query could survive a dump/re-parse cycle.
-				ss << "(declare-datatypes ((" << sort_name << " " << sort->arity << ")) ((";
-				bool first_ctor = true;
-				for(const auto& ctor : sort->getDtConstructors()){
-					if(!first_ctor) ss << " ";
-					first_ctor = false;
-					datatype_member_names.insert(ctor.name);
-					datatype_member_names.insert("is-" + ctor.name);
-					ss << "(" << ctor.name;
-					for(const auto& sel : ctor.selectors){
-						datatype_member_names.insert(sel.name);
-						ss << " (" << sel.name << " " << sel.sort->toString() << ")";
+				// Emitted below, in dependency groups. A datatype whose
+				// selector names another datatype cannot be declared before
+				// it, and MUTUALLY recursive ones cannot be declared apart at
+				// all -- SMT-LIB puts a whole group in one command for exactly
+				// that reason.
+				datatype_order.push_back(sort_name);
+			}
+		}
+		// (declare-datatypes ((T 0) (TL 0)) ((<T ctors>) (<TL ctors>)))
+		//
+		// One command per group of mutually recursive datatypes, groups in
+		// dependency order. Emitting one command per SORT is what this did, and
+		// it produced a script THIS PARSER COULD NOT READ for any mutually
+		// recursive pair: `T` mentions `TL` in a selector, `TL` is declared in
+		// the next command, and re-parsing failed with `Unknown or unexpected
+		// symbol "TL"`. dumpSMT2 returned that text and reported nothing.
+		//
+		// A datatype that depends on nothing still gets its own command, so the
+		// output for every non-mutual script is unchanged.
+		if(!datatype_order.empty()){
+			const auto ctors_of = [&](const std::string& n)
+				-> const std::vector<Sort::DtConstructor>* {
+				auto i = sort_map.find(n);
+				if(i == sort_map.end() || !i->second) return nullptr;
+				return &i->second->getDtConstructors();
+			};
+			// A -> B when a selector of A has sort B. Collected by NAME, since
+			// a placeholder sort and the finished one are different objects.
+			std::unordered_map<std::string, std::unordered_set<std::string>> deps;
+			std::unordered_set<std::string> is_dt(datatype_order.begin(),
+			                                      datatype_order.end());
+			for(const auto& n : datatype_order){
+				const auto* cs = ctors_of(n);
+				if(!cs) continue;
+				for(const auto& c : *cs){
+					for(const auto& sel : c.selectors){
+						if(!sel.sort) continue;
+						const std::string& t = sel.sort->name;
+						if(t != n && is_dt.count(t)) deps[n].insert(t);
+					}
+				}
+			}
+			// Tarjan, iterative-free: the graph has one node per datatype and a
+			// script does not declare enough of them for recursion depth to be
+			// a concern. Groups come out in reverse topological order, which is
+			// the order they must be DECLARED in -- a group's dependencies
+			// finish first.
+			std::unordered_map<std::string, int> index, low;
+			std::unordered_set<std::string> on_stack;
+			std::vector<std::string> stack;
+			std::vector<std::vector<std::string>> groups;
+			int next_index = 0;
+			std::function<void(const std::string&)> strongconnect =
+				[&](const std::string& v){
+					index[v] = low[v] = next_index++;
+					stack.push_back(v);
+					on_stack.insert(v);
+					auto it = deps.find(v);
+					if(it != deps.end()){
+						for(const auto& w : it->second){
+							if(index.find(w) == index.end()){
+								strongconnect(w);
+								low[v] = std::min(low[v], low[w]);
+							} else if(on_stack.count(w)){
+								low[v] = std::min(low[v], index[w]);
+							}
+						}
+					}
+					if(low[v] == index[v]){
+						std::vector<std::string> group;
+						for(;;){
+							const std::string w = stack.back();
+							stack.pop_back();
+							on_stack.erase(w);
+							group.push_back(w);
+							if(w == v) break;
+						}
+						groups.push_back(std::move(group));
+					}
+				};
+			for(const auto& n : datatype_order){
+				if(index.find(n) == index.end()) strongconnect(n);
+			}
+			for(auto& group : groups){
+				// Declaration order within a group, so a one-element group and
+				// a group of three both read the way the script declared them.
+				std::sort(group.begin(), group.end(),
+				          [&](const std::string& a, const std::string& b){
+					          return std::find(datatype_order.begin(),
+					                           datatype_order.end(), a)
+					               < std::find(datatype_order.begin(),
+					                           datatype_order.end(), b);
+				          });
+				ss << "(declare-datatypes (";
+				for(std::size_t gi = 0; gi < group.size(); ++gi){
+					auto i = sort_map.find(group[gi]);
+					const size_t ar = (i != sort_map.end() && i->second)
+					                      ? i->second->arity : 0;
+					if(gi) ss << " ";
+					ss << "(" << group[gi] << " " << ar << ")";
+				}
+				ss << ") (";
+				for(std::size_t gi = 0; gi < group.size(); ++gi){
+					const auto* cs = ctors_of(group[gi]);
+					if(gi) ss << " ";
+					ss << "(";
+					bool first_ctor = true;
+					if(cs){
+						for(const auto& ctor : *cs){
+							if(!first_ctor) ss << " ";
+							first_ctor = false;
+							datatype_member_names.insert(ctor.name);
+							datatype_member_names.insert("is-" + ctor.name);
+							ss << "(" << ctor.name;
+							for(const auto& sel : ctor.selectors){
+								datatype_member_names.insert(sel.name);
+								ss << " (" << sel.name << " "
+								   << sel.sort->toString() << ")";
+							}
+							ss << ")";
+						}
 					}
 					ss << ")";
 				}
-				ss << ")))" << std::endl;
+				ss << "))" << std::endl;
 			}
 		}
 		// variables

--- a/test/regression/test_datatype_groups.cpp
+++ b/test/regression/test_datatype_groups.cpp
@@ -1,0 +1,164 @@
+// A group of mutually recursive datatypes is one command, and was two.
+//
+// SMT-LIB declares a whole group in a single `declare-datatypes` precisely so
+// that its members may refer to each other: the sort names are all in scope
+// before any constructor list is read. `dumpSMT2` emitted one command per SORT,
+// which is right for a datatype that stands alone and impossible for a pair
+// that does not:
+//
+//     (declare-datatypes ((T 0)) (((node (kids TL)) ...)))   <- TL not declared
+//     (declare-datatypes ((TL 0)) (((tcons (thd T) ...))))
+//
+// Re-parsing that failed with `Unknown or unexpected symbol "TL"`. The dump
+// returned the text and reported nothing, so a script this parser had read
+// perfectly came back out unreadable -- by itself, and by anything else.
+//
+// The fix groups by strongly connected component and emits the groups in
+// dependency order. A datatype that depends on nothing keeps its own command,
+// so the output of every non-mutual script is byte-for-byte what it was.
+
+#include "somtparser/parser.h"
+
+#include <iostream>
+#include <string>
+
+#include "test_helpers.h"
+
+using namespace SOMTParser;
+
+namespace {
+
+bool has(const std::string& hay, const std::string& needle) {
+    return hay.find(needle) != std::string::npos;
+}
+
+std::size_t count(const std::string& hay, const std::string& needle) {
+    std::size_t n = 0;
+    for (std::size_t i = hay.find(needle); i != std::string::npos;
+         i = hay.find(needle, i + 1)) {
+        ++n;
+    }
+    return n;
+}
+
+/** Parse, dump, and require the dump to read back -- which is the property
+ *  this file is about, so it is checked on every case rather than once. */
+std::string roundTrip(const std::string& script, const char* what) {
+    ParserPtr p = newParser();
+    if (!p->parseStr(script)) {
+        std::cout << "  failed to parse (" << what << "):\n" << script;
+        VERIFY(false);
+    }
+    const std::string out = p->dumpSMT2();
+    ParserPtr q = newParser();
+    if (!q->parseStr(out)) {
+        std::cout << "  dump does not read back (" << what << "):\n" << out;
+        VERIFY(false);
+    }
+    // And is stable: a second dump equals the first, so the grouping does not
+    // drift on each pass.
+    VERIFY(q->dumpSMT2() == out);
+    return out;
+}
+
+} // namespace
+
+int main() {
+    std::cout << "======= datatype declaration groups =======\n";
+
+    // ---- Mutually recursive: ONE command. ----------------------------------
+    {
+        const std::string out = roundTrip(
+            "(set-logic ALL)\n"
+            "(declare-datatypes ((T 0) (TL 0))"
+            " (((node (kids TL)) (leaf (val Int))) ((tnil) (tcons (thd T) (ttl TL)))))\n"
+            "(declare-const t T)\n(assert ((_ is leaf) t))\n(check-sat)\n",
+            "mutual recursion");
+        VERIFY(count(out, "(declare-datatypes") == 1);
+        VERIFY(has(out, "(T 0) (TL 0)"));
+    }
+    {
+        // Three in a cycle, to check the grouping is not a two-element special
+        // case dressed up as a general one.
+        const std::string out = roundTrip(
+            "(set-logic ALL)\n"
+            "(declare-datatypes ((A 0) (B 0) (C 0))"
+            " (((mkA (toB B))) ((mkB (toC C))) ((mkC (toA A)) (stop))))\n"
+            "(declare-const a A)\n(assert ((_ is mkA) a))\n(check-sat)\n",
+            "three-cycle");
+        VERIFY(count(out, "(declare-datatypes") == 1);
+    }
+
+    // ---- Standing alone: unchanged, one command each. -----------------------
+    {
+        // The case every existing script and every corpus file is, so its
+        // output must be exactly what it was before the grouping existed.
+        const std::string out = roundTrip(
+            "(set-logic ALL)\n"
+            "(declare-datatypes ((Lst 0)) (((nil) (cons (hd Int) (tl Lst)))))\n"
+            "(declare-const l Lst)\n(assert ((_ is cons) l))\n(check-sat)\n",
+            "self-recursive");
+        VERIFY(count(out, "(declare-datatypes") == 1);
+        VERIFY(has(out,
+                   "(declare-datatypes ((Lst 0)) (((nil) (cons (hd Int) (tl Lst)))))"));
+    }
+    {
+        // Two that do not refer to each other stay two commands. Merging them
+        // would be legal SMT-LIB and would still change the shape of a script
+        // that had nothing wrong with it.
+        const std::string out = roundTrip(
+            "(set-logic ALL)\n"
+            "(declare-datatypes ((A 0)) (((a1) (a2))))\n"
+            "(declare-datatypes ((B 0)) (((b1) (b2))))\n"
+            "(declare-const x A)\n(declare-const y B)\n"
+            "(assert ((_ is a1) x))\n(check-sat)\n",
+            "two independent");
+        VERIFY(count(out, "(declare-datatypes") == 2);
+    }
+
+    // ---- One-way dependency: the dependency comes FIRST. --------------------
+    {
+        // Not mutual, so two commands -- but the order is forced, and it is not
+        // the declaration order in general. Here it happens to agree; the next
+        // case is the one where it does not.
+        const std::string out = roundTrip(
+            "(set-logic ALL)\n"
+            "(declare-datatypes ((B 0)) (((b1) (b2))))\n"
+            "(declare-datatypes ((A 0)) (((wrap (unwrap B)))))\n"
+            "(declare-const x A)\n(assert ((_ is wrap) x))\n(check-sat)\n",
+            "dependency in declaration order");
+        VERIFY(count(out, "(declare-datatypes") == 2);
+        VERIFY(out.find("(B 0)") < out.find("(A 0)"));
+    }
+    {
+        // The same two declared in ONE command, where the group lists A before
+        // the B it needs. Split into two, they must come out B first -- the
+        // order the reader needs, not the order the writer used.
+        const std::string out = roundTrip(
+            "(set-logic ALL)\n"
+            "(declare-datatypes ((A 0) (B 0)) (((wrap (unwrap B))) ((b1) (b2))))\n"
+            "(declare-const x A)\n(assert ((_ is wrap) x))\n(check-sat)\n",
+            "dependency against declaration order");
+        VERIFY(out.find("(B 0)") < out.find("(A 0)"));
+    }
+
+    // ---- The members are still not declared twice. -------------------------
+    {
+        // A datatype declaration registers a function for every constructor,
+        // selector and tester. Emitting those as declare-funs beside the
+        // datatype makes the script refuse itself as a redeclaration, and the
+        // grouping rewrite moved the code that collects their names.
+        const std::string out = roundTrip(
+            "(set-logic ALL)\n"
+            "(declare-datatypes ((T 0) (TL 0))"
+            " (((node (kids TL)) (leaf (val Int))) ((tnil) (tcons (thd T) (ttl TL)))))\n"
+            "(declare-const t T)\n(assert ((_ is leaf) t))\n(check-sat)\n",
+            "no duplicate members");
+        VERIFY(!has(out, "(declare-fun node"));
+        VERIFY(!has(out, "(declare-fun val"));
+        VERIFY(!has(out, "(declare-fun is-leaf"));
+    }
+
+    std::cout << "All datatype-group tests passed." << std::endl;
+    return 0;
+}

--- a/test/regression/test_datatype_groups.cpp
+++ b/test/regression/test_datatype_groups.cpp
@@ -159,6 +159,45 @@ int main() {
         VERIFY(!has(out, "(declare-fun is-leaf"));
     }
 
+    // ---- The dependency may be NESTED inside a sort. -----------------------
+    //
+    // A selector of sort `(Array Int TL)` depends on TL exactly as one of sort
+    // `TL` does. Reading only the outermost sort name missed the edge, so the
+    // two datatypes landed in different groups, were emitted as separate
+    // commands, and the second was named before it was declared -- this file's
+    // own defect, reached through a sort constructor instead of directly.
+    {
+        const std::string out = roundTrip(
+            "(declare-datatypes ((T 0) (TL 0))"
+            " (((node (kids (Array Int TL))) (leaf))"
+            "  ((tnil) (tcons (thd T)))))\n",
+            "mutual recursion through an array");
+        // One command, not two: they are one strongly connected component.
+        VERIFY(count(out, "(declare-datatypes") == 1);
+    }
+    {
+        // And two levels down, which a scan that looked one level deep would
+        // still miss.
+        const std::string out = roundTrip(
+            "(declare-datatypes ((U 0) (V 0))"
+            " (((u1 (uv (Array Int (Array Int V)))) (u2))"
+            "  ((v1 (vu U)))))\n",
+            "mutual recursion two sorts deep");
+        VERIFY(count(out, "(declare-datatypes") == 1);
+    }
+    {
+        // A ONE-WAY nested dependency still gets two commands, in the right
+        // order: grouping is for cycles, and merging independent datatypes
+        // would change output that was already correct.
+        const std::string out = roundTrip(
+            "(declare-datatypes ((W 0) (Z 0))"
+            " (((w1 (wz (Array Int Z))))"
+            "  ((z1) (z2))))\n",
+            "one-way dependency through an array");
+        VERIFY(count(out, "(declare-datatypes") == 2);
+        VERIFY(out.find("(Z 0)") < out.find("(W 0)"));
+    }
+
     std::cout << "All datatype-group tests passed." << std::endl;
     return 0;
 }


### PR DESCRIPTION
SMT-LIB declares a whole group of datatypes in a **single** `declare-datatypes` precisely so its members may refer to each other: every sort name in the group is in scope before any constructor list is read.

`dumpSMT2` emitted one command per **sort**. That is right for a datatype that stands alone and impossible for a pair that does not:

```smt2
(declare-datatypes ((T 0)) (((node (kids TL)) (leaf (val Int)))))   ; TL undeclared
(declare-datatypes ((TL 0)) (((tnil) (tcons (thd T) (ttl TL)))))
```

Re-parsing that fails with `Unknown or unexpected symbol "TL"` — and the dump returns the text reporting nothing, so a script this parser had read perfectly came back out unreadable, by itself and by anything else.

### The change

Datatypes are grouped by strongly connected component and the groups emitted in dependency order. That also fixes the **one-way** case, which is a quieter version of the same bug: a datatype whose selector names another must be declared after it, and declaration order does not guarantee that —

```smt2
(declare-datatypes ((A 0) (B 0)) (((wrap (unwrap B))) ((b1) (b2))))
```

split naively puts `A` first and names `B` before declaring it.

### What does not change

A datatype that depends on nothing keeps its own command, so the output of **every non-mutual script is byte-for-byte what it was**. Two independent datatypes stay two commands rather than being merged into one legal-but-different group.

### Testing

`test/regression/test_datatype_groups.cpp` — mutual recursion of two and of three, the standalone and two-independent cases pinned as unchanged, one-way dependency in both declaration orders, and the constructors/selectors/testers still not emitted a second time as `declare-fun`s. Every case asserts the dump reads back **and** that a second dump equals the first, so the grouping cannot drift on each pass.

Full suite: 54/54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
