### PR TITLE
fix(parse): `str.indexof_re` takes three arguments

### DIFF
--- a/include/somtparser/frontend/parser.h
+++ b/include/somtparser/frontend/parser.h
@@ -3008,7 +3008,7 @@ namespace SOMTParser{
          * @param r Regular expression
          * @return String indexof-regex node (str.indexof_re(l, r))
          */
-        std::shared_ptr<DAGNode> mkStrIndexofReg(std::shared_ptr<DAGNode> l, std::shared_ptr<DAGNode> r); // str.indexof_re(l, r)
+        std::shared_ptr<DAGNode> mkStrIndexofReg(std::shared_ptr<DAGNode> l, std::shared_ptr<DAGNode> r, std::shared_ptr<DAGNode> i); // str.indexof_re(l, r, i)
 
         /**
          * @brief Create a string to-lower node

--- a/src/frontend/expr_parser.cpp
+++ b/src/frontend/expr_parser.cpp
@@ -1468,8 +1468,8 @@ namespace SOMTParser{
                 condAssert(oper_params.size() == 3, "Invalid number of parameters for str.replace_re_all");
                 return mkStrReplaceRegAll(oper_params[0], oper_params[1], oper_params[2]);
             case NODE_KIND::NT_STR_INDEXOF_REG:
-                condAssert(oper_params.size() == 2, "Invalid number of parameters for str.indexof_re");
-                return mkStrIndexofReg(oper_params[0], oper_params[1]);
+                condAssert(oper_params.size() == 3, "Invalid number of parameters for str.indexof_re");
+                return mkStrIndexofReg(oper_params[0], oper_params[1], oper_params[2]);
             case NODE_KIND::NT_STR_TO_LOWER:
                 condAssert(oper_params.size() == 1, "Invalid number of parameters for str.to_lower");
                 return mkStrToLower(oper_params[0]);

--- a/src/frontend/op_parser.cpp
+++ b/src/frontend/op_parser.cpp
@@ -4237,13 +4237,18 @@ namespace SOMTParser{
     /*
     (str.indexof_re Str Reg), return Int
     */
-    std::shared_ptr<DAGNode> Parser::mkStrIndexofReg(std::shared_ptr<DAGNode> l, std::shared_ptr<DAGNode> r){
-        if(l->isErr() || r->isErr()) return l->isErr()?l:r;
-        if(!isStrParam(l) || !isRegParam(r)) {
+    std::shared_ptr<DAGNode> Parser::mkStrIndexofReg(std::shared_ptr<DAGNode> l, std::shared_ptr<DAGNode> r,
+                                                     std::shared_ptr<DAGNode> i){
+        if(l->isErr() || r->isErr() || i->isErr()) return l->isErr()?l:(r->isErr()?r:i);
+        // (str.indexof_re String RegLan Int) Int -- three arguments, the third
+        // the index to start from, exactly as str.indexof takes one. Built with
+        // two, so a conforming script was a parse failure and a term built
+        // through the API named an operator with the wrong arity.
+        if(!isStrParam(l) || !isRegParam(r) || !isIntParam(i)) {
             err_all(ERROR_TYPE::ERR_TYPE_MIS, "Type mismatch in str_indexof_re", line_number);
             return mkUnknown();
         }
-        return mkOper(SortManager::INT_SORT, NODE_KIND::NT_STR_INDEXOF_REG, l, r);
+        return mkOper(SortManager::INT_SORT, NODE_KIND::NT_STR_INDEXOF_REG, l, r, i);
     }
 
     /*

--- a/test/api/test_evaluate_fp_dispatch.cpp
+++ b/test/api/test_evaluate_fp_dispatch.cpp
@@ -108,8 +108,8 @@ int main() {
 (assert (= s "aba"))
 (assert (= t "aaa"))
 
-; Binary: str.indexof_re
-(assert (>= (str.indexof_re s (str.to_re "b")) 0))
+; Ternary: str.indexof_re takes a start index, like str.indexof
+(assert (>= (str.indexof_re s (str.to_re "b") 0) 0))
 
 ; Ternary: str.replace_re / str.replace_re_all
 (assert (= (str.replace_re s (str.to_re "a") "x") "xbx"))
@@ -200,7 +200,7 @@ int main() {
     }
 
     // --- Phase B: string / regex dispatch (no constant folding yet): structure + constant leaves preserved ---
-    eval_expect_structure_unchanged(parser, model, "(str.indexof_re \"abc\" (str.to_re \"b\"))");
+    eval_expect_structure_unchanged(parser, model, "(str.indexof_re \"abc\" (str.to_re \"b\") 0)");
     eval_expect_structure_unchanged(parser, model, "(str.replace_re \"aba\" (str.to_re \"a\") \"x\")");
     eval_expect_structure_unchanged(parser, model, "(str.replace_re_all \"aaa\" (str.to_re \"a\") \"b\")");
     eval_expect_structure_unchanged(parser, model, "((_ re.loop 1 2) (str.to_re \"x\"))");

--- a/test/instances/eval_dispatch_qf_s.smt2
+++ b/test/instances/eval_dispatch_qf_s.smt2
@@ -6,8 +6,10 @@
 (assert (= s "aba"))
 (assert (= t "aaa"))
 
-; Binary: str.indexof_re
-(assert (>= (str.indexof_re s (str.to_re "b")) 0))
+; Ternary: str.indexof_re takes a start index, like str.indexof.
+; This fixture said "Binary" and used two arguments, which is what the
+; parser accepted and not what SMT-LIB declares.
+(assert (>= (str.indexof_re s (str.to_re "b") 0) 0))
 
 ; Ternary: str.replace_re / str.replace_re_all
 (assert (= (str.replace_re s (str.to_re "a") "x") "xbx"))

--- a/test/regression/test_str_indexof_re.cpp
+++ b/test/regression/test_str_indexof_re.cpp
@@ -1,0 +1,95 @@
+// `str.indexof_re` takes three arguments.
+//
+// SMT-LIB's Unicode Strings theory declares
+//
+//     (str.indexof_re String RegLan Int) Int
+//
+// -- the third argument is the index to start searching from, exactly as
+// `str.indexof` takes one. This parser built it with two, so a conforming
+// script was a parse failure and a term built through the API named the
+// operator at an arity nothing else uses.
+//
+// The arity table in getArity already said 3. The builder and the dispatch
+// said 2. That is the same disagreement between copies that `<=` had, in a
+// smaller place: one operator's arity written down more than once, and the
+// copies drifting.
+
+#include "somtparser/parser.h"
+
+#include <iostream>
+#include <string>
+
+#include "test_helpers.h"
+
+using namespace SOMTParser;
+
+namespace {
+
+bool has(const std::string& hay, const std::string& needle) {
+    return hay.find(needle) != std::string::npos;
+}
+
+const char* kDecl = "(set-logic ALL)\n(declare-const t String)\n"
+                    "(declare-const i Int)\n";
+
+} // namespace
+
+int main() {
+    std::cout << "======= str.indexof_re =======\n";
+
+    // ---- Three arguments parse, and survive a round trip. ------------------
+    {
+        ParserPtr p = newParser();
+        const std::string src = std::string(kDecl)
+            + "(assert (> (str.indexof_re t (str.to_re \"a\") 0) 0))\n(check-sat)\n";
+        if (!p->parseStr(src)) {
+            std::cout << "  three arguments did not parse\n";
+            VERIFY(false);
+        }
+        const std::string out = p->dumpSMT2();
+        VERIFY(has(out, "str.indexof_re"));
+        ParserPtr q = newParser();
+        VERIFY(q->parseStr(out));
+        VERIFY(q->dumpSMT2() == out);
+    }
+    {
+        // A non-constant start index is ordinary: it is a term, not an index in
+        // the `(_ ...)` sense.
+        ParserPtr p = newParser();
+        VERIFY(p->parseStr(std::string(kDecl)
+                           + "(assert (> (str.indexof_re t (str.to_re \"a\") i) 0))\n"
+                             "(check-sat)\n"));
+    }
+
+    // ---- Two arguments are an error, not a lenient shorthand. --------------
+    {
+        // Accepting them would leave the start index unstated, and the operator
+        // has no default: `str.indexof` does not have one either.
+        ParserPtr p = newParser();
+        VERIFY(!p->parseStr(std::string(kDecl)
+                            + "(assert (> (str.indexof_re t (str.to_re \"a\")) 0))\n"
+                              "(check-sat)\n"));
+    }
+    {
+        // ...and the third argument must be an Int, not another regular
+        // expression, which is the mistake the two-argument form invited.
+        ParserPtr p = newParser();
+        VERIFY(!p->parseStr(std::string(kDecl)
+                            + "(assert (> (str.indexof_re t (str.to_re \"a\") "
+                              "(str.to_re \"b\")) 0))\n(check-sat)\n"));
+    }
+
+    // ---- The two neighbours it sits between are unchanged. -----------------
+    {
+        // str.replace_re and str.replace_re_all were already three-argument;
+        // this checks the dispatch edit did not shift them.
+        ParserPtr p = newParser();
+        VERIFY(p->parseStr(std::string(kDecl)
+                           + "(assert (= (str.replace_re t (str.to_re \"a\") t) t))\n"
+                             "(assert (= (str.replace_re_all t (str.to_re \"a\") t) t))\n"
+                             "(check-sat)\n"));
+    }
+
+    std::cout << "All str.indexof_re tests passed." << std::endl;
+    return 0;
+}


### PR DESCRIPTION
SMT-LIB's Unicode Strings theory declares

```
(str.indexof_re String RegLan Int) Int
```

The third argument is the index to start searching from, exactly as `str.indexof` takes one. This parser built it with **two**, so a conforming script was a parse failure and a term built through the API named the operator at an arity nothing else uses.

### The same shape as the chainable comparisons

`getArity`'s table already said **3**. The builder and the dispatch said **2** — and the two neighbours in that same dispatch, `str.replace_re` and `str.replace_re_all`, were three from the first. One operator's arity written down more than once, and the copies drifting apart.

### Two fixtures encoded the wrong arity

`test/instances/eval_dispatch_qf_s.smt2` and `test/api/test_evaluate_fp_dispatch.cpp` both used the two-argument form, one under a comment reading `; Binary: str.indexof_re`. They were describing the parser rather than the standard, and both are corrected.

### Testing

`test/regression/test_str_indexof_re.cpp` — three arguments parse and round-trip, a non-constant start index works, two arguments are an error rather than a lenient shorthand, a `RegLan` in the third position is rejected, and the two neighbouring three-argument operators are pinned as unchanged.

The accepted set over **224 SMT-LIB benchmarks** is unchanged file by file. Full suite: 54/54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
