### PR TITLE
fix(dump): quote a symbol SMT-LIB cannot spell bare

### DIFF
--- a/include/somtparser/ir/dag.h
+++ b/include/somtparser/ir/dag.h
@@ -52,6 +52,12 @@
 #include <array>
 
 namespace SOMTParser{
+
+/** A symbol as SMT-LIB can legally spell it: returned unchanged when it is a
+ *  valid simple symbol, and wrapped in `|...|` when it is not. See the
+ *  definition in dag.cpp for why the choice has to be made when printing. */
+std::string smtSymbol(const std::string& name);
+
     // Forward declaration of DAGNode class
     class DAGNode;
     

--- a/src/frontend/base_parser.cpp
+++ b/src/frontend/base_parser.cpp
@@ -3624,7 +3624,7 @@ namespace SOMTParser{
 		// variables
 		std::vector<std::shared_ptr<DAGNode>> vars = getVariables();
 		for(auto& var : vars){
-			ss << "(declare-fun " << var->getName() << " () " << var->getSort()->toString() << ")" << std::endl;
+			ss << "(declare-fun " << smtSymbol(var->getName()) << " () " << var->getSort()->toString() << ")" << std::endl;
 		}
 	std::vector<std::shared_ptr<DAGNode>> functions = getFunctions();
 	// Members of a (define-funs-rec ...) group are emitted together, at the

--- a/src/ir/dag.cpp
+++ b/src/ir/dag.cpp
@@ -89,6 +89,45 @@ namespace SOMTParser{
         return result;
     }
 
+    /** A symbol as SMT-LIB can legally spell it.
+     *
+     *  SMT-LIB 2.6 §3.1 gives a symbol two spellings: a SIMPLE symbol, whose
+     *  characters are letters, digits and `~!@$%^&*_-+=<>.?/` and which may not
+     *  start with a digit; and a QUOTED one, `|...|`, which may contain
+     *  anything but `|` and `\`. The two denote the same symbol, so choosing
+     *  between them is a printing decision.
+     *
+     *  It was not being made. A name that arrived quoted was printed quoted,
+     *  because the bars were kept as part of the name; a name built through the
+     *  public API was printed exactly as given. So a variable created as
+     *  `x(1)` -- legal through mkVar, and a perfectly ordinary identifier in
+     *  several input languages this library reads -- was emitted as
+     *
+     *      (declare-fun x(1) () Int)
+     *
+     *  which is not a well-formed command. No other solver accepts it, and this
+     *  library reads it back only because getSymbol() scans leniently, so the
+     *  defect did not show up in a round trip through this parser alone.
+     *
+     *  Quoting is applied where the symbol is printed rather than where it is
+     *  stored, because the stored name is the symbol's identity and `x(1)` and
+     *  `|x(1)|` are the same symbol. */
+    std::string smtSymbolImpl(const std::string& name) {
+        if (name.empty()) { return "||"; }
+        if (name.size() >= 2 && name.front() == '|' && name.back() == '|') {
+            return name;                       // already quoted; do not double it
+        }
+        auto simple = [](char c) {
+            return std::isalnum(static_cast<unsigned char>(c)) != 0
+                || std::strchr("~!@$%^&*_-+=<>.?/", c) != nullptr;
+        };
+        bool ok = std::isdigit(static_cast<unsigned char>(name.front())) == 0;
+        for (const char c : name) {
+            if (!simple(c)) { ok = false; break; }
+        }
+        return ok ? name : "|" + name + "|";
+    }
+
     std::string dumpConst(const std::string& name, const std::shared_ptr<Sort>& sort){
         // Rational a/b form is only meaningful for ARITHMETIC sorts.  It must
         // never apply to other sorts: a string literal may legitimately
@@ -347,7 +386,7 @@ namespace SOMTParser{
             case NODE_KIND::NT_VAR:
             case NODE_KIND::NT_TEMP_VAR:
             case NODE_KIND::NT_PLACEHOLDER_VAR:
-                out << node->getName();
+                out << smtSymbolImpl(node->getName());
                 break;
             case NODE_KIND::NT_CONST_ARRAY: {
                 out << "((as const ";
@@ -1561,4 +1600,8 @@ namespace SOMTParser{
         return insertNodeToBucket(node);
     }
 
+}
+
+namespace SOMTParser {
+std::string smtSymbol(const std::string& name) { return smtSymbolImpl(name); }
 }

--- a/test/regression/test_symbol_quoting.cpp
+++ b/test/regression/test_symbol_quoting.cpp
@@ -1,0 +1,109 @@
+// A symbol the API accepts must be one SMT-LIB can spell.
+//
+// SMT-LIB 2.6 §3.1 gives a symbol two spellings. A SIMPLE symbol is made of
+// letters, digits and `~!@$%^&*_-+=<>.?/` and may not begin with a digit; a
+// QUOTED one, `|...|`, may contain anything except `|` and `\`. The two denote
+// the same symbol, so which to write is a decision made when printing.
+//
+// It was not being made. A name that arrived quoted stayed quoted, because the
+// bars were part of the stored name; a name built through the API was printed
+// exactly as given. A variable created as `x(1)` -- which mkVar accepts, and
+// which is an ordinary identifier in several input languages -- was therefore
+// emitted as
+//
+//     (declare-fun x(1) () Int)
+//
+// which is not a well-formed command. No other solver reads it, and this
+// library reads it back only because getSymbol() scans leniently, so a round
+// trip through this parser alone did not reveal it.
+//
+// The assertions below are on the emitted TEXT and on its re-parse, because
+// that is where the defect lived: every stage before printing was content with
+// the name.
+
+#include "somtparser/frontend/parser.h"
+
+#include <iostream>
+#include <string>
+
+#include "test_helpers.h"
+
+using namespace SOMTParser;
+
+namespace {
+
+bool has(const std::string& hay, const std::string& needle) {
+    return hay.find(needle) != std::string::npos;
+}
+
+/** Declare a variable of the given name through the API and dump the script. */
+std::string dumpWithVar(const std::string& name) {
+    ParserPtr p = newParser();
+    std::shared_ptr<DAGNode> v = p->mkVar(p->mkIntSort(), name);
+    // `Parser::assert` is a member function, so parser.h undefines the macro;
+    // <cassert> must be included after it, and this file does not need it.
+    p->assert(p->mkGt(v, p->mkConstInt(0)));
+    return p->dumpSMT2();
+}
+
+} // namespace
+
+int main() {
+    std::cout << "======= symbol quoting when printing =======\n";
+
+    // ---- A name needing quotes gets them, and the script re-parses. --------
+    {
+        const std::string smt = dumpWithVar("x(1)");
+        VERIFY(has(smt, "|x(1)|"));
+        // The unquoted form must not appear anywhere -- not in the declaration
+        // and not in the assertion, which is a separate print site.
+        VERIFY(!has(smt, "(declare-fun x(1) "));
+        ParserPtr r = newParser();
+        VERIFY(r->parseStr(smt));
+    }
+    {
+        // A leading digit is the other way a simple symbol can be invalid.
+        const std::string smt = dumpWithVar("1st");
+        VERIFY(has(smt, "|1st|"));
+        ParserPtr r = newParser();
+        VERIFY(r->parseStr(smt));
+    }
+    {
+        // Whitespace, which cannot appear in a simple symbol at all.
+        const std::string smt = dumpWithVar("a b");
+        VERIFY(has(smt, "|a b|"));
+        ParserPtr r = newParser();
+        VERIFY(r->parseStr(smt));
+    }
+
+    // ---- An ordinary name is left ALONE. -----------------------------------
+    //
+    // The fix must not quote everything: `|x|` and `x` are the same symbol, so
+    // quoting unnecessarily would be correct and unreadable, and it would churn
+    // the output of every existing script.
+    {
+        const std::string smt = dumpWithVar("x");
+        VERIFY(has(smt, "(declare-fun x () Int)"));
+        VERIFY(!has(smt, "|x|"));
+    }
+    {
+        // The punctuation SMT-LIB does allow in a simple symbol stays bare.
+        const std::string smt = dumpWithVar("a-b_c.d?e");
+        VERIFY(has(smt, "(declare-fun a-b_c.d?e () Int)"));
+        VERIFY(!has(smt, "|a-b_c.d?e|"));
+    }
+
+    // ---- A name that arrives quoted is not quoted twice. -------------------
+    {
+        ParserPtr p = newParser();
+        VERIFY(p->parseStr("(declare-fun |y z| () Int)\n(assert (> |y z| 0))\n"));
+        const std::string smt = p->dumpSMT2();
+        VERIFY(has(smt, "|y z|"));
+        VERIFY(!has(smt, "||y z||"));
+        ParserPtr r = newParser();
+        VERIFY(r->parseStr(smt));
+    }
+
+    std::cout << "All symbol-quoting tests passed." << std::endl;
+    return 0;
+}


### PR DESCRIPTION
SMT-LIB 2.6 §3.1 gives a symbol two spellings. A **simple** symbol is made of letters, digits and `~!@$%^&*_-+=<>.?/` and may not begin with a digit; a **quoted** one, `|...|`, may contain anything except `|` and `\`. The two denote the same symbol, so which one to write is a decision made when printing.

That decision was not being made. A name that arrived quoted stayed quoted, because the bars were part of the stored name, and a name built through the public API was printed exactly as given. A variable created as `x(1)` — which `mkVar` accepts, and which is an ordinary identifier in several of the input languages this library reads — was therefore emitted as

```
(declare-fun x(1) () Int)
```

which is not a well-formed command. No other solver reads it, and this library reads it back only because `getSymbol()` scans leniently, so a round trip through this parser alone did not reveal it.

## The change

`smtSymbol()` quotes a name that is not a valid simple symbol, leaves one that already is, and does not double the bars on a name that arrived quoted. It is applied when **printing** rather than when storing, because the stored name is the symbol's identity and `x(1)` and `|x(1)|` are the same symbol — the same principle as #52.

Applied at the two sites that print a **variable**: the identifier case in `dumpSMT2` and the `declare-fun` line. Other node kinds print a bare name at about nineteen further sites and want the same treatment; they are left for a change of their own rather than folded into this one.

## Tests

`test/regression/test_symbol_quoting.cpp` asserts on the emitted **text** and on its re-parse, since that is where the defect lived — every stage before printing was content with the name. It covers three ways a simple symbol can be invalid (punctuation, a leading digit, whitespace), that an ordinary name is left alone (quoting everything would be correct and unreadable), and that a name arriving quoted is not quoted twice.

Verified by breaking the guarded line and confirming the test fails.

54/54 existing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
