### PR TITLE
fix(simp): string constants had two spellings, and four operators read the wrong one

### DIFF
--- a/src/frontend/op_parser.cpp
+++ b/src/frontend/op_parser.cpp
@@ -756,14 +756,30 @@ namespace SOMTParser{
         }
         return mkConstReal(v.toReal());
     }
+    /** A string constant, stored in ONE canonical form.
+     *
+     *  Nodes are hash-consed by name, so two spellings of the same value are
+     *  two different nodes and an equality between them folds to FALSE. This
+     *  function stored a quoted argument with its quotes and an unquoted
+     *  argument without, so a constant built through the API and the identical
+     *  literal read from a script were never the same node:
+     *
+     *      (= (str.from_int 7) "7")     folded to false
+     *
+     *  -- str.from_int calls this with `7` and the parser calls it with `"7"`.
+     *  Both PRINT as `"7"`, because printing adds the quotes when they are
+     *  missing, so the disagreement was invisible in the output and showed up
+     *  only as an equality that would not hold.
+     *
+     *  The two spellings denote the same value, so exactly one of them may be
+     *  the stored form. Quoted is chosen because it is what the parser produces
+     *  and what getStringLiteral() already strips. */
     std::shared_ptr<DAGNode> Parser::mkConstStr(const std::string &v){
-        // process the escape characters in the string
-        std::string processed_v = v;
-        // if the string is quoted, remove the quotes
+        std::string raw = v;
         if (v.length() >= 2 && v[0] == '"' && v[v.length()-1] == '"') {
-            processed_v = ConversionUtils::unescapeString(v.substr(1, v.length()-2));
-            processed_v = "\"" + ConversionUtils::escapeString(processed_v) + "\"";
+            raw = ConversionUtils::unescapeString(v.substr(1, v.length()-2));
         }
+        const std::string processed_v = "\"" + ConversionUtils::escapeString(raw) + "\"";
         return getNodeManager()->createNode(SortManager::STR_SORT, NODE_KIND::NT_CONST, processed_v);
     }
     std::shared_ptr<DAGNode> Parser::mkConstBv(const std::string &v, const size_t& width){

--- a/src/frontend/simp_parser.cpp
+++ b/src/frontend/simp_parser.cpp
@@ -727,13 +727,20 @@ namespace SOMTParser{
             }
             case NODE_KIND::NT_STR_REV:{
                 if(p->isCStr()){
-                    return mkConstStr(StringUtils::strRev(p->toString()));
+                    return mkConstStr(StringUtils::strRev(p->getStringLiteral()));
                 }
                 return mkUnknown();
             }
+            // `str.is_digit` holds for a ONE-CHARACTER string that is a digit,
+            // and for nothing else. It was sharing `str.to_int`'s test, so a
+            // longer run of digits satisfied it too and `(str.is_digit "77")`
+            // folded to true.
             case NODE_KIND::NT_STR_IS_DIGIT:{
                 if(p->isCStr()){
-                    return TypeChecker::isInt(p->toString()) ? mkTrue() : mkFalse();
+                    const std::string v = p->getStringLiteral();
+                    const bool one_digit =
+                        v.size() == 1 && v[0] >= '0' && v[0] <= '9';
+                    return one_digit ? mkTrue() : mkFalse();
                 }
                 return mkUnknown();
             }
@@ -743,27 +750,50 @@ namespace SOMTParser{
                 }
                 return mkUnknown();
             }
+            // **`str.to_int` returns -1; it does not fail.** SMT-LIB defines it
+            // total: a string that is not a non-empty run of digits maps to -1,
+            // so `(str.to_int "abc")` is a well-formed term with a value.
+            // Raising an error turned a legal script into a parse failure.
+            //
+            // It also read `toString()`, which renders a string constant WITH
+            // its quotes, so the digit test saw `"7"` rather than `7` and every
+            // literal took the error branch -- `(str.to_int "7")` included.
+            // `getStringLiteral()` is the accessor for the value, and the
+            // NT_STR_LEN case above was already using it.
             case NODE_KIND::NT_STR_TO_INT:{
                 if(p->isCStr()){
-                    if(TypeChecker::isInt(p->toString())){
-                        return mkConstInt(stoi(p->toString()));
+                    const std::string v = p->getStringLiteral();
+                    bool digits = !v.empty();
+                    for(const char c : v){
+                        if(c < '0' || c > '9'){ digits = false; break; }
                     }
-                    else{
-                        err_all(p, "String to int on non-integer", line_number);
+                    if(!digits){ return mkConstInt(-1); }
+                    // Leading zeroes are digits, so "0007" is 7.
+                    try{
+                        return mkConstInt(Integer(v));
+                    }
+                    catch(...){
+                        // Too large for the integer type rather than malformed.
+                        // Left unfolded, which is sound: the term keeps its
+                        // meaning and a solver may still reason about it.
                         return mkUnknown();
                     }
                 }
                 return mkUnknown();
             }
+            // `str.to_code` is total too: -1 for anything that is not a
+            // one-character string. Same two defects as str.to_int above -- an
+            // error where the standard has a value, and the quoted rendering
+            // where the value was wanted, which made `"a"` three characters
+            // long so no literal ever reached the folding branch.
             case NODE_KIND::NT_STR_TO_CODE:{
                 if(p->isCStr()){
-                    if(p->toString().size() == 1){
-                        return mkConstInt(static_cast<int>(p->toString()[0]));
+                    const std::string v = p->getStringLiteral();
+                    if(v.size() == 1){
+                        return mkConstInt(static_cast<int>(
+                            static_cast<unsigned char>(v[0])));
                     }
-                    else{
-                        err_all(p, "String to code on non-single character string", line_number);
-                        return mkUnknown();
-                    }
+                    return mkConstInt(-1);
                 }
                 return mkUnknown();
             }

--- a/test/regression/test_string_const_folding.cpp
+++ b/test/regression/test_string_const_folding.cpp
@@ -1,0 +1,96 @@
+// String operators applied to STRING CONSTANTS.
+//
+// Constant folding in simp_oper only fires when an argument IS a constant, so
+// a test that exercises an operator over a declared variable never reaches it.
+// Four defects lived in that gap, and all four are about a string constant
+// having two spellings:
+//
+//   * `str.to_int` and `str.to_code` RAISED AN ERROR for an argument the
+//     standard gives a value. Both are total in SMT-LIB -- a string that is not
+//     a run of digits maps to -1, a string that is not one character maps to -1
+//     -- so `(str.to_int "abc")` is a well-formed term, and erroring turned a
+//     legal script into a parse failure.
+//
+//   * `str.to_int`, `str.to_code`, `str.is_digit` and `str.rev` read
+//     `toString()`, which renders a string constant WITH its quotes. So the
+//     is-it-digits test saw `"7"` rather than `7`, and `"a"` was three
+//     characters long: no literal ever reached the folding branch, including
+//     `(str.to_int "7")`. `getStringLiteral()` is the accessor for the value,
+//     and the NT_STR_LEN case beside them was already using it.
+//
+//   * `str.is_digit` was sharing `str.to_int`'s test, so a run of digits
+//     satisfied it and `(str.is_digit "77")` folded to true.
+//
+//   * `mkConstStr` stored a quoted argument with its quotes and an unquoted one
+//     without. Nodes are hash-consed by name, so a constant built through the
+//     API and the identical literal read from a script were never the same node
+//     and `(= (str.from_int 7) "7")` folded to FALSE. Both PRINT as `"7"`,
+//     because printing adds the quotes when they are missing, so it was
+//     invisible in the output and showed up only as an equality that would not
+//     hold.
+//
+// The assertions are on the VALUE rather than on acceptance: each expression is
+// folded and compared against what the standard says it equals, so a folder
+// that returns the wrong number fails rather than one that merely returns.
+
+#include "somtparser/frontend/parser.h"
+
+#include <iostream>
+#include <string>
+
+#include "test_helpers.h"
+
+using namespace SOMTParser;
+
+namespace {
+
+/** Parse `(assert <e>)` and report whether it folded to `true`. A fully folded
+ *  true is the only outcome that means "the value is what the standard says". */
+bool foldsTrue(const std::string& e) {
+    ParserPtr p = newParser();
+    if (!p->parseStr("(assert " + e + ")\n(check-sat)\n")) { return false; }
+    const std::string out = p->dumpSMT2();
+    return out.find("(assert true)") != std::string::npos;
+}
+
+} // namespace
+
+int main() {
+    std::cout << "======= string operators over constants =======\n";
+
+    // ---- str.to_int: total, and -1 is a value rather than an error. ---------
+    VERIFY(foldsTrue("(= (str.to_int \"7\") 7)"));
+    // Leading zeroes are digits, so "0007" is 7 -- not -1, which is what a
+    // reader that rejected the spelling would give.
+    VERIFY(foldsTrue("(= (str.to_int \"0007\") 7)"));
+    VERIFY(foldsTrue("(= (str.to_int \"abc\") (- 1))"));
+    VERIFY(foldsTrue("(= (str.to_int \"\") (- 1))"));
+    // A mixed string is not a run of digits, so it is -1 and not a prefix.
+    VERIFY(foldsTrue("(= (str.to_int \"12a\") (- 1))"));
+    VERIFY(foldsTrue("(= (str.to_int \"-3\") (- 1))"));
+
+    // ---- str.to_code: the code point, or -1. -------------------------------
+    VERIFY(foldsTrue("(= (str.to_code \"a\") 97)"));
+    VERIFY(foldsTrue("(= (str.to_code \"A\") 65)"));
+    VERIFY(foldsTrue("(= (str.to_code \"ab\") (- 1))"));
+    VERIFY(foldsTrue("(= (str.to_code \"\") (- 1))"));
+
+    // ---- str.is_digit: ONE digit character. --------------------------------
+    VERIFY(foldsTrue("(str.is_digit \"7\")"));
+    VERIFY(foldsTrue("(not (str.is_digit \"77\"))"));
+    VERIFY(foldsTrue("(not (str.is_digit \"a\"))"));
+    VERIFY(foldsTrue("(not (str.is_digit \"\"))"));
+
+    // ---- One canonical spelling for a constant. -----------------------------
+    //
+    // The two sides of each equality reach mkConstStr by different routes: one
+    // from an operator that built the value, one from the parser reading a
+    // literal. They must be the same node.
+    VERIFY(foldsTrue("(= (str.from_int 7) \"7\")"));
+    VERIFY(foldsTrue("(= (str.rev \"abc\") \"cba\")"));
+    VERIFY(foldsTrue("(= (str.++ \"ab\" \"c\") \"abc\")"));
+    VERIFY(foldsTrue("(= (str.len \"abc\") 3)"));
+
+    std::cout << "All string constant-folding tests passed." << std::endl;
+    return 0;
+}


### PR DESCRIPTION
Constant folding in `simp_oper` fires only when an argument **is** a constant, so an operator exercised over a declared variable never reaches it. Four defects lived in that gap, and all four are about a string constant having two spellings.

## `str.to_int` failed on every string literal

`(str.to_int "7")` included. Two faults in one case:

- It read `toString()`, which renders a string constant **with** its quotes, so the is-it-digits test saw `"7"` rather than `7` and no literal ever took the folding branch. `getStringLiteral()` is the accessor for the value, and the `NT_STR_LEN` case beside it was already using it.
- It then **raised an error** for a non-numeric string, where SMT-LIB defines the operator total: a string that is not a non-empty run of digits maps to `-1`. `(str.to_int "abc")` is a well-formed term with a value, and erroring turned a legal script into a parse failure.

`str.to_code` had both faults. `str.is_digit` and `str.rev` had the quoting one, and `str.is_digit` was additionally sharing `str.to_int`'s test, so a run of digits satisfied it and `(str.is_digit "77")` folded to `true` — a run of digits is not a digit.

## `(= (str.from_int 7) "7")` folded to FALSE

`mkConstStr` stored a quoted argument with its quotes and an unquoted one without, and nodes are hash-consed by name — so a constant built through the API and the identical literal read from a script were never the same node.

Both **print** as `"7"`, because printing adds the quotes when they are missing, so the disagreement was invisible in the output and surfaced only as an equality that would not hold. The two spellings denote one value, so exactly one of them may be the stored form; quoted is chosen because it is what the parser produces and what `getStringLiteral()` already strips.

## Tests

`test/regression/test_string_const_folding.cpp` asserts **values** — what each expression equals under the standard — rather than acceptance, so a folder that returns the wrong number fails rather than one that merely returns.

54/54 existing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
