### PR TITLE
feat(parse): parametric datatypes, and the sorts they construct

### DIFF
--- a/include/somtparser/frontend/parser.h
+++ b/include/somtparser/frontend/parser.h
@@ -4108,6 +4108,40 @@ namespace SOMTParser{
         std::shared_ptr<DAGNode>                parseMatch();
         /** Parse one <datatype_dec> ((ctor...)...) after its opening '('; register ctors/selectors/testers on @p dt_sort. */
         void                                    defineDatatypeConstructors(const std::shared_ptr<Sort>& dt_sort);
+        /** Reads an optional `(par (X ...)` wrapper before a datatype's
+         *  constructor list and returns the parameter names, empty when the body
+         *  is not parametric. Leaves the buffer where the plain form would. */
+        std::vector<std::string>                parseDatatypeParams();
+        /** Sort-parameter binding for an application of a parametric datatype's
+         *  member. See the definition for how selectors, testers and
+         *  constructors each determine it. */
+        void                                    dtParamBinding(const std::shared_ptr<DAGNode>& fun,
+                                                    const std::vector<std::shared_ptr<DAGNode>>& params,
+                                                    std::unordered_map<std::string, std::shared_ptr<Sort>>& out);
+    public:
+        /** The result sort an application of @p fun should carry, with a
+         *  parametric datatype's parameters substituted. Returns the declared
+         *  sort unchanged for everything else. */
+        std::shared_ptr<Sort>                   dtAppliedSort(const std::shared_ptr<DAGNode>& fun,
+                                                    const std::vector<std::shared_ptr<DAGNode>>& params);
+        /** A parametric datatype's sort parameters, in declaration order; empty
+         *  for an ordinary one. A Sort records only the arity, so a caller that
+         *  needs the names has to ask here. */
+        std::vector<std::string>                datatypeParams(const std::string& dt) const {
+            const auto it = datatype_params_.find(dt);
+            return it == datatype_params_.end() ? std::vector<std::string>{} : it->second;
+        }
+        /** Record a parametric datatype's parameter names, for a caller that
+         *  builds a model programmatically rather than parsing a script. */
+        void                                    setDatatypeParams(const std::string& dt,
+                                                    const std::vector<std::string>& p) {
+            datatype_params_[dt] = p;
+        }
+    private:
+        /** Sort-parameter names per parametric datatype, in declaration order.
+         *  A Sort records its ARITY and not what its parameters were called, so
+         *  dumpSMT2 could not otherwise write the `par` form back. */
+        std::unordered_map<std::string, std::vector<std::string>> datatype_params_;
         
         // parse optimization
         // single_opt = (maximize <expr> [:comp <symbol>] [:epsilon <symbol>] [:M <symbol>] [:id <symbol>]) 

--- a/include/somtparser/ir/sort.h
+++ b/include/somtparser/ir/sort.h
@@ -169,7 +169,15 @@ namespace SOMTParser{
             // script the standard forbids parsed and translated with no
             // diagnostic. The array and set branches below compare their
             // children for this reason; a declared constructor needs it too.
-            if((isDef() || isDec()) && (other.isDef() || other.isDec())
+            //
+            // A PARAMETRIC DATATYPE needs the same treatment, for the same
+            // reason and with the same consequence. `(declare-datatypes ((L 1))
+            // ((par (X) ...)))` makes L a sort constructor, so `(L Int)` and
+            // `(L Bool)` are two sorts; comparing by name alone let a value of
+            // one be used where the other was declared. An arity-0 datatype has
+            // no children and is unaffected.
+            if((isDef() || isDec() || isDatatype())
+               && (other.isDef() || other.isDec() || other.isDatatype())
                && name == other.name && arity == other.arity){
                 if(children.size() != other.children.size()) return false;
                 for(size_t i = 0; i < children.size(); i++){
@@ -238,7 +246,18 @@ namespace SOMTParser{
                     return "(_ FloatingPoint " + std::to_string(children[0]->arity) + " " + std::to_string(children[1]->arity) + ")";
                 case SORT_KIND::SK_STR: return "String";
                 case SORT_KIND::SK_ARRAY: return "(Array " + children[0]->toString() + " " + children[1]->toString() + ")";
-                case SORT_KIND::SK_DATATYPE: return name.empty() ? "Datatype" : name;
+                // A PARAMETRIC datatype applied to arguments must print them:
+                // `(L X)` is not `L`. SK_DEC below already does this, and a
+                // datatype sort constructor was left returning its bare name --
+                // so `(tl (L X))` dumped as `(tl L)`, a constructor at the wrong
+                // arity, which nothing else reads.
+                case SORT_KIND::SK_DATATYPE: {
+                    if(name.empty()) return "Datatype";
+                    if(children.empty()) return name;
+                    std::string s = "(" + name;
+                    for(const auto& ch : children) s += " " + (ch ? ch->toString() : "?");
+                    return s + ")";
+                }
                 case SORT_KIND::SK_SET: return "Set";
                 case SORT_KIND::SK_RELATION: return "Relation";
                 case SORT_KIND::SK_BAG: return "Bag";

--- a/src/frontend/base_parser.cpp
+++ b/src/frontend/base_parser.cpp
@@ -1237,7 +1237,29 @@ namespace SOMTParser{
 			getSymbolManager()->registerSort(dt_name, ps);
 			context_.registerSortInScope(dt_name);
 			parseLpar();
-			defineDatatypeConstructors(ps);
+			// `(declare-datatype Pair (par (A B) (...)))`. The arity is not
+			// written in this form -- it is the number of parameters -- so it is
+			// set from what `par` declares.
+			{
+				const std::vector<std::string> params = parseDatatypeParams();
+				if (!params.empty()) {
+					ps->arity = params.size();
+					datatype_params_[dt_name] = params;
+					for (const std::string& pn : params) {
+						getSymbolManager()->registerSort(
+							pn, getSortManager()->createSort(
+								SORT_KIND::SK_DEC, pn, 0));
+						context_.registerSortInScope(pn);
+					}
+				}
+				defineDatatypeConstructors(ps);
+				// Out of scope again: a parameter is bound by its `par` and the
+				// next command must not see it.
+				for (const std::string& pn : params) {
+					getSymbolManager()->removeSort(pn);
+				}
+				if (!params.empty()) { parseRpar(); }   // close the `par`
+			}
 			skipToRpar();
 			return CMD_TYPE::CT_DECLARE_DATATYPES;
 		}
@@ -1275,8 +1297,26 @@ namespace SOMTParser{
 			parseLpar(); // outer '(' for datatype list
 			for(size_t ti = 0; ti < sort_decls.size(); ++ti) {
 				parseLpar(); // '(' for this datatype
+				// `(par (X) (<ctors>))` when the sort was declared with a
+				// non-zero arity. The parameters are in scope only while this
+				// datatype's constructors are read.
+				const std::vector<std::string> params = parseDatatypeParams();
+				if (!params.empty()) {
+					datatype_params_[sort_decls[ti].first] = params;
+					for (const std::string& pn : params) {
+						getSymbolManager()->registerSort(
+							pn, getSortManager()->createSort(
+								SORT_KIND::SK_DEC, pn, 0));
+						context_.registerSortInScope(pn);
+					}
+				}
 				defineDatatypeConstructors(placeholder_sorts[ti]);
+				for (const std::string& pn : params) {
+					getSymbolManager()->removeSort(pn);
+				}
+				if (!params.empty()) { parseRpar(); }   // close the `par`
 			}
+
 			parseRpar(); // close outer datatype list
 			skipToRpar(); // close the declare-datatypes command
 
@@ -1992,6 +2032,22 @@ namespace SOMTParser{
 			// then check the user-defined type
 			else {
 				std::shared_ptr<Sort> usort = getSymbolManager()->resolveSort(s);
+				// A PARAMETRIC datatype's name is a sort CONSTRUCTOR, and a
+				// constructor is not a sort until it is applied: `L` alone has
+				// no more meaning than `Array` alone. Accepting it declared
+				// variables at a non-sort, and the dump then said
+				// `(declare-fun l () L)` -- an arity-1 name used at arity 0,
+				// which nothing reads back.
+				if(usort && usort->isDatatype() && usort->getChildrenSize() == 0){
+					const std::vector<std::string> ps = datatypeParams(s);
+					if(!ps.empty()){
+						err_arity_mis(s + " (a datatype taking " +
+						              std::to_string(ps.size()) +
+						              " sort argument(s), used with none)",
+						              expr_ln);
+						return SortManager::NULL_SORT;
+					}
+				}
 				if(usort) return usort;
 				err_unkwn_sym(s, expr_ln);
 			}
@@ -2359,6 +2415,138 @@ namespace SOMTParser{
 		return symbol;
 	}
 
+	/** The key under which dtParamBinding records the APPLIED datatype sort for a
+	 *  constructor, whose declared result is the bare name. Not a valid SMT-LIB
+	 *  symbol, so it cannot collide with a parameter. */
+	static const char* const kDtSelfKey = "\x01self";
+
+	/** Collect a parameter binding by matching a DECLARED sort against an ACTUAL
+	 *  one. Names in @p names are the parameters; anything else must agree
+	 *  structurally, and a disagreement is reported by the caller's sort check
+	 *  rather than here. */
+	static void matchSortParams(const std::shared_ptr<Sort>& declared,
+	                            const std::shared_ptr<Sort>& actual,
+	                            const std::unordered_set<std::string>& names,
+	                            std::unordered_map<std::string, std::shared_ptr<Sort>>& out){
+		if(!declared || !actual) return;
+		if(names.count(declared->name)){
+			if(out.find(declared->name) == out.end()) out[declared->name] = actual;
+			return;
+		}
+		const size_t n = std::min(declared->children.size(), actual->children.size());
+		for(size_t i = 0; i < n; i++){
+			matchSortParams(declared->children[i], actual->children[i], names, out);
+		}
+	}
+
+	/** Replace every parameter in @p s by its binding. Returns @p s unchanged
+	 *  when it mentions none, so a non-parametric datatype costs nothing. */
+	static std::shared_ptr<Sort> substituteSortParams(
+			const std::shared_ptr<Sort>& s,
+			const std::unordered_map<std::string, std::shared_ptr<Sort>>& b){
+		if(!s || b.empty()) return s;
+		const auto it = b.find(s->name);
+		if(it != b.end()) return it->second;
+		bool any = false;
+		std::vector<std::shared_ptr<Sort>> kids;
+		kids.reserve(s->children.size());
+		for(const auto& ch : s->children){
+			std::shared_ptr<Sort> r = substituteSortParams(ch, b);
+			if(r != ch) any = true;
+			kids.push_back(r);
+		}
+		if(!any) return s;
+		auto out = std::make_shared<Sort>(*s);
+		out->children = kids;
+		return out;
+	}
+
+	/** The sort-parameter binding for an application of a PARAMETRIC datatype's
+	 *  member, empty when the datatype has none.
+	 *
+	 *  A member is polymorphic and its declaration records the parameters
+	 *  rather than an instance: `hd` is declared `L -> X`, so applying it to an
+	 *  `(L Int)` must give `Int` and not `X` -- a sort no longer in scope, over
+	 *  which the next operator reports a type mismatch naming a symbol the
+	 *  script never wrote.
+	 *
+	 *  For a SELECTOR or TESTER the argument determines everything: its sort is
+	 *  the instance, and its sort arguments are the parameters in order. Its
+	 *  declared domain cannot serve, because that is the BARE datatype -- `L`
+	 *  carrying its arity and no arguments -- with nothing in it to match a
+	 *  parameter against.
+	 *
+	 *  For a CONSTRUCTOR the parameters appear among the argument sorts, so they
+	 *  are matched structurally; the result is the bare datatype name and is
+	 *  applied to the bindings in parameter order, under the reserved key below.
+	 *  A constructor that mentions no parameter -- `nil` -- cannot be resolved
+	 *  this way and needs the script's own `(as nil (L Int))`.
+	 */
+	void Parser::dtParamBinding(const std::shared_ptr<DAGNode>& fun,
+	                            const std::vector<std::shared_ptr<DAGNode>>& params,
+	                            std::unordered_map<std::string, std::shared_ptr<Sort>>& out){
+		if(!fun) return;
+		const std::vector<std::shared_ptr<DAGNode>> declared = fun->getFuncParams();
+		const std::shared_ptr<Sort> ret = fun->getSort();
+		const std::string dt_name = ret ? ret->name : std::string();
+		const auto pit = datatype_params_.find(dt_name);
+		const std::string arg_dt =
+			(!params.empty() && params[0] && params[0]->getSort())
+				? params[0]->getSort()->name : std::string();
+		const auto ait = datatype_params_.find(arg_dt);
+		const std::vector<std::string>* names = nullptr;
+		if(pit != datatype_params_.end()) names = &pit->second;
+		else if(ait != datatype_params_.end()) names = &ait->second;
+		if(!names || names->empty()) return;
+
+		const std::unordered_set<std::string> nameset(names->begin(), names->end());
+		if(ait != datatype_params_.end() && !params.empty() && params[0]
+		   && params[0]->getSort()){
+			const std::shared_ptr<Sort> inst = params[0]->getSort();
+			const auto& kids = inst->children;
+			for(size_t i = 0; i < names->size() && i < kids.size(); i++){
+				out[(*names)[i]] = kids[i];
+			}
+			// The datatype's own NAME binds to the instance. A selector's
+			// declared domain is the BARE datatype -- `hd : L -> X`, with `L`
+			// carrying its arity and no arguments -- and an applied instance is
+			// a different sort from it now that a datatype's arguments count in
+			// a comparison. Without this binding `(hd (tl l))` fails its own
+			// argument check: `tl` correctly returns `(L Int)`, and `hd`
+			// declares it takes `L`.
+			if(!kids.empty()) out[arg_dt] = inst;
+		}
+		for(size_t i = 0; i < params.size() && i < declared.size(); i++){
+			if(!declared[i] || !params[i]) continue;
+			matchSortParams(declared[i]->getSort(), params[i]->getSort(), nameset, out);
+		}
+		if(pit != datatype_params_.end() && ret && ret->children.empty()
+		   && out.size() >= names->size()){
+			auto applied = std::make_shared<Sort>(*ret);
+			bool complete = true;
+			for(const std::string& pn : *names){
+				const auto b = out.find(pn);
+				if(b == out.end()){ complete = false; break; }
+				applied->children.push_back(b->second);
+			}
+			if(complete) out[kDtSelfKey] = applied;
+		}
+	}
+
+	/** The result sort an application should carry. Returns the declared sort
+	 *  unchanged for a non-parametric datatype and for everything else, so the
+	 *  cost is one failed map lookup on the ordinary path. */
+	std::shared_ptr<Sort> Parser::dtAppliedSort(
+			const std::shared_ptr<DAGNode>& fun,
+			const std::vector<std::shared_ptr<DAGNode>>& params){
+		std::unordered_map<std::string, std::shared_ptr<Sort>> b;
+		dtParamBinding(fun, params, b);
+		if(b.empty()) return fun ? fun->getSort() : nullptr;
+		const auto self = b.find(kDtSelfKey);
+		if(self != b.end()) return self->second;
+		return substituteSortParams(fun->getSort(), b);
+	}
+
 	std::shared_ptr<DAGNode> Parser::applyFun(std::shared_ptr<DAGNode> fun, const std::vector<std::shared_ptr<DAGNode>> & params){
 		// check the number of params
 		if (fun->getFuncParamsSize() != params.size()){
@@ -2381,9 +2569,17 @@ namespace SOMTParser{
 		// compares equal to both Int and Real, so `(f 1)` against an Int or a
 		// Real parameter still applies.
 		const std::vector<std::shared_ptr<DAGNode>> declared = fun->getFuncParams();
+
+		// A member of a PARAMETRIC datatype is polymorphic, and its declaration
+		// records the parameters rather than any instance of them, so both the
+		// argument check and the result sort are taken after substituting them.
+		std::unordered_map<std::string, std::shared_ptr<Sort>> dt_binding;
+		dtParamBinding(fun, params, dt_binding);
+
 		for (size_t i = 0; i < params.size() && i < declared.size(); i++){
 			if (!declared[i] || !params[i]) continue;
-			const std::shared_ptr<Sort> want = declared[i]->getSort();
+			const std::shared_ptr<Sort> want =
+				substituteSortParams(declared[i]->getSort(), dt_binding);
 			const std::shared_ptr<Sort> got = params[i]->getSort();
 			// A missing sort on either side is someone else's error to report;
 			// refusing here would turn it into a misleading one.
@@ -2397,7 +2593,14 @@ namespace SOMTParser{
 		if(fun->getFuncBody()->isNull()){
 			// Determine if this is a datatype constructor/selector/tester
 			NODE_KIND nk = getDtFunctionKind(fun->getSort(), fun->getName(), params);
-			std::shared_ptr<DAGNode> result = getNodeManager()->createNode(fun->getSort(), nk, fun->getName(), params);
+			std::shared_ptr<Sort> ret_sort = fun->getSort();
+			if(!dt_binding.empty()){
+				const auto self = dt_binding.find(kDtSelfKey);
+				ret_sort = self != dt_binding.end()
+					? self->second
+					: substituteSortParams(ret_sort, dt_binding);
+			}
+			std::shared_ptr<DAGNode> result = getNodeManager()->createNode(ret_sort, nk, fun->getName(), params);
 			return result;
 		}
 
@@ -2582,6 +2785,44 @@ namespace SOMTParser{
     std::shared_ptr<DAGNode> Parser::mkApplyUF(const std::shared_ptr<Sort>& sort, const std::string &name, const std::vector<std::shared_ptr<DAGNode>> &params){
         NODE_KIND nk = getDtFunctionKind(sort, name, params);
         return getNodeManager()->createNode(sort, nk, name, params);
+    }
+
+    /** `(par (X Y) (<ctors>))` -- SMT-LIB's PARAMETRIC datatype body.
+     *
+     *  The parameters are sorts, and inside the body they are ordinary sorts in
+     *  scope: `(cons (hd X) (tl (L X)))` needs `X` to resolve while the
+     *  constructors are read and needs it gone afterwards, or the next command
+     *  would see a sort the script never declared.
+     *
+     *  Returns the parameter names, empty when the body is not parametric. The
+     *  names are kept because they are not recoverable from the sort -- a sort
+     *  records its ARITY and not what its parameters were called -- and
+     *  dumpSMT2 has to write the same `par` form back.
+     *
+     *  Leaves the buffer positioned exactly where the non-parametric form
+     *  would, so the caller does not branch. */
+    std::vector<std::string> Parser::parseDatatypeParams() {
+        char* const save = bufptr;
+        const size_t save_line = line_number;
+        std::vector<std::string> params;
+        // `par` sits where a constructor's `(` would, so a symbol here means
+        // the parametric form and anything else means the plain one.
+        if (*bufptr == '(') { return params; }
+        std::string head = getSymbol();
+        if (head != "par") {
+            bufptr = save;
+            line_number = save_line;
+            return params;
+        }
+        scanToNextSymbol();           // getSymbol stops AT the symbol's end
+        parseLpar();
+        while (*bufptr != ')') {
+            params.push_back(getSymbol());
+            scanToNextSymbol();
+        }
+        parseRpar();
+        parseLpar();                  // the constructor list's own '('
+        return params;
     }
 
     void Parser::defineDatatypeConstructors(const std::shared_ptr<Sort>& dt_sort) {
@@ -3725,6 +3966,22 @@ namespace SOMTParser{
 					const auto* cs = ctors_of(group[gi]);
 					if(gi) ss << " ";
 					ss << "(";
+					// A PARAMETRIC datatype's body is wrapped in `par`, which
+					// binds the sort names its selectors mention. The names are
+					// not recoverable from the sort -- a Sort records its arity
+					// and not what its parameters were called -- so they are
+					// carried in datatype_params_ from the declaration.
+					const auto pit = datatype_params_.find(group[gi]);
+					const bool parametric = pit != datatype_params_.end()
+						&& !pit->second.empty();
+					if(parametric){
+						ss << "par (";
+						for(std::size_t pi = 0; pi < pit->second.size(); ++pi){
+							if(pi) ss << " ";
+							ss << pit->second[pi];
+						}
+						ss << ") (";
+					}
 					bool first_ctor = true;
 					if(cs){
 						for(const auto& ctor : *cs){
@@ -3741,6 +3998,7 @@ namespace SOMTParser{
 							ss << ")";
 						}
 					}
+					if(parametric){ ss << ")"; }      // close the `par`
 					ss << ")";
 				}
 				ss << "))" << std::endl;

--- a/src/frontend/expr_parser.cpp
+++ b/src/frontend/expr_parser.cpp
@@ -157,6 +157,35 @@ namespace SOMTParser{
                                 frame.state = FrameState::Finish;
                                 break;
                             }
+                            else if(std::shared_ptr<DAGNode> dtf =
+                                        getSymbolManager()->getFun(second)){
+                                // `(as nil (L Int))` -- ASCRIBING which instance
+                                // of a parametric datatype a constructor builds.
+                                // A constructor mentioning none of the
+                                // parameters has no arguments to infer them
+                                // from, so SMT-LIB makes the script say. Without
+                                // this a parametric datatype has declarations
+                                // and no way to build a value.
+                                //
+                                // The ascribed sort becomes the term's, so `nil`
+                                // at `(L Int)` and at `(L Bool)` are different
+                                // terms rather than one shared node.
+                                const std::vector<std::shared_ptr<DAGNode>> none;
+                                const NODE_KIND dtk =
+                                    getDtFunctionKind(dtf->getSort(), second, none);
+                                if(dtk != NODE_KIND::NT_DT_CONSTRUCTOR){
+                                    err_unkwn_sym("as " + second, frame.line);
+                                    frame.result = mkErr(ERROR_TYPE::ERR_UNKWN_SYM);
+                                    frame.state = FrameState::Finish;
+                                    break;
+                                }
+                                std::shared_ptr<Sort> want = parseSort();
+                                parseRpar(); // close (as C S)
+                                frame.result = getNodeManager()->createNode(
+                                    want, dtk, second, none);
+                                frame.state = FrameState::Finish;
+                                break;
+                            }
                             else{
                                 err_unkwn_sym("as " + second, frame.line);
                                 frame.result = mkErr(ERROR_TYPE::ERR_UNKWN_SYM);
@@ -230,6 +259,32 @@ namespace SOMTParser{
                     // read the head symbol
                     std::string head = getSymbol();
                     frame.headSymbol = head;
+
+                    // `(as nil (L Int))` is a COMPLETE term, not an annotation
+                    // applied to arguments, so it arrives here rather than in
+                    // the `((as const T) value)` branch above: the two `as`
+                    // forms differ in whether the annotation is the operator or
+                    // the whole term, and they are separate code paths.
+                    if(head == "as"){
+                        const std::string what = getSymbol();
+                        if(std::shared_ptr<DAGNode> dtf = getSymbolManager()->getFun(what)){
+                            const std::vector<std::shared_ptr<DAGNode>> none;
+                            const NODE_KIND dtk =
+                                getDtFunctionKind(dtf->getSort(), what, none);
+                            if(dtk == NODE_KIND::NT_DT_CONSTRUCTOR){
+                                std::shared_ptr<Sort> want = parseSort();
+                                parseRpar();
+                                frame.result = getNodeManager()->createNode(
+                                    want, dtk, what, none);
+                                frame.state = FrameState::Finish;
+                                break;
+                            }
+                        }
+                        err_unkwn_sym("as " + what, frame.line);
+                        frame.result = mkErr(ERROR_TYPE::ERR_UNKWN_SYM);
+                        frame.state = FrameState::Finish;
+                        break;
+                    }
 
                     if(head == "exists" || head == "forall"){
                         in_quantifier_scope = true;
@@ -878,7 +933,13 @@ namespace SOMTParser{
 			NODE_KIND dtk = getDtFunctionKind(func->getSort(), s, oper_params);
 			if(dtk == NODE_KIND::NT_DT_TESTER || dtk == NODE_KIND::NT_DT_CONSTRUCTOR ||
 			   dtk == NODE_KIND::NT_DT_SELECTOR){
-				return getNodeManager()->createNode(func->getSort(), dtk, s, oper_params);
+				// A PARAMETRIC datatype's member is polymorphic, so the sort the
+				// application carries is the declared one with the parameters
+				// substituted: `hd` of an `(L Int)` is an Int, not an `X`. This
+				// path intercepts the application before applyFun, so it needs
+				// the same substitution rather than func->getSort() raw.
+				return getNodeManager()->createNode(
+					dtAppliedSort(func, oper_params), dtk, s, oper_params);
 			}
 		}
 		// Non-indexed (op ...): user define-fun / define-fun-rec / pending declare-fun (body) may shadow only allow_builtin_shadow names.

--- a/src/ir/dag.cpp
+++ b/src/ir/dag.cpp
@@ -749,7 +749,20 @@ namespace SOMTParser{
                 // Constructor application: (CtorName arg1 arg2 ...) or just CtorName
                 const auto& children = node->getChildren();
                 if (children.empty()) {
-                    out << node->getName();
+                    // A NULLARY constructor of a PARAMETRIC datatype must keep
+                    // its sort ascription. `nil` names a constructor of every
+                    // instance of `L` at once, and having no arguments there is
+                    // nothing to infer the instance from -- which is why SMT-LIB
+                    // requires `(as nil (L Int))`. Printing the bare name gave a
+                    // term this parser had built at a definite sort and could
+                    // not read back at any.
+                    std::shared_ptr<Sort> s = node->getSort();
+                    if (s && s->isDatatype() && s->getChildrenSize() > 0) {
+                        out << "(as " << node->getName() << " " << s->toString()
+                            << ")";
+                    } else {
+                        out << node->getName();
+                    }
                 } else {
                     out << "(" << node->getName();
                     work_stack.emplace_back(nullptr, 2);  // )

--- a/test/regression/test_parametric_datatypes.cpp
+++ b/test/regression/test_parametric_datatypes.cpp
@@ -1,0 +1,235 @@
+// Parametric datatypes: `(par (X) ...)`, and the sorts it makes.
+//
+// SMT-LIB 2.6 lets a datatype declaration abstract over sorts:
+//
+//     (declare-datatype L (par (X) ((nil) (cons (hd X) (tl (L X))))))
+//
+// which declares ONE datatype and, with it, a family of sorts -- `(L Int)`,
+// `(L Bool)`, `(L (L Int))` -- and members whose sorts follow the argument:
+// `hd` of an `(L Int)` is an Int, of an `(L Bool)` a Bool. The parser had no
+// `par` at all, so a conforming script stopped at its first declaration.
+//
+// Getting `par` read is the small half. The rest is that `L` is now a sort
+// CONSTRUCTOR rather than a sort, and every place that treated a datatype name
+// as a complete sort was quietly wrong:
+//
+//   * a selector's sort is the DECLARED one with the parameters substituted,
+//     not the declared one as written -- `hd` returns `X` and must yield Int;
+//   * a nullary constructor names a member of every instance at once, so with
+//     no argument to infer from there is nothing to fix the instance. SMT-LIB
+//     requires `(as nil (L Int))`, and the ascription has to SURVIVE PRINTING:
+//     dumping the bare name gave a term this parser had built at a definite
+//     sort and could not read back at any;
+//   * `L` alone is not a sort, so a variable cannot be declared at it. It was
+//     accepted, and dumped as `(declare-fun l () L)` -- an arity-1 name used
+//     at arity 0.
+//
+// Every case below asserts the round trip, because "parses" and "prints
+// something a reader accepts" came apart here in three separate places.
+
+#include "somtparser/parser.h"
+
+#include <iostream>
+#include <string>
+
+#include "test_helpers.h"
+
+using namespace SOMTParser;
+
+namespace {
+
+const char* kL =
+    "(declare-datatype L (par (X) ((nil) (cons (hd X) (tl (L X))))))\n";
+
+bool has(const std::string& hay, const std::string& needle) {
+    return hay.find(needle) != std::string::npos;
+}
+
+/** Parse, dump, re-parse, and require the second dump to equal the first. */
+std::string roundTrip(const std::string& script, const char* what) {
+    ParserPtr p = newParser();
+    if (!p->parseStr(script)) {
+        std::cout << "  failed to parse (" << what << "):\n" << script;
+        VERIFY(false);
+    }
+    const std::string out = p->dumpSMT2();
+    ParserPtr q = newParser();
+    if (!q->parseStr(out)) {
+        std::cout << "  dump does not read back (" << what << "):\n" << out;
+        VERIFY(false);
+    }
+    if (q->dumpSMT2() != out) {
+        std::cout << "  dump is not stable (" << what << "):\n"
+                  << out << "  became:\n" << q->dumpSMT2();
+        VERIFY(false);
+    }
+    return out;
+}
+
+/** A script the parser must REFUSE. `parseStr` returns false rather than
+ *  throwing, per the parser's contract, but a throw is also a refusal. */
+void refuses(const std::string& script, const char* what) {
+    ParserPtr p = newParser();
+    bool accepted = false;
+    try {
+        accepted = p->parseStr(script);
+    } catch (const std::exception&) {
+        accepted = false;
+    }
+    if (accepted) {
+        std::cout << "  accepted, should refuse (" << what << "):\n"
+                  << p->dumpSMT2();
+        VERIFY(false);
+    }
+}
+
+} // namespace
+
+int main() {
+    std::cout << "======= parametric datatypes =======\n";
+
+    // ---- The declaration itself, in both spellings. -------------------------
+    {
+        // Singular `declare-datatype` with the parameter list.
+        const std::string out = roundTrip(
+            std::string(kL) + "(declare-const l (L Int))\n"
+            "(assert (= (hd l) 3))\n(check-sat)\n",
+            "singular declare-datatype");
+        // The arity is 1, and the `par` is what carries it.
+        VERIFY(has(out, "(declare-datatypes ((L 1)) ((par (X) "));
+        // The parameter is NOT a sort in its own right, so it must not be
+        // emitted as one.
+        VERIFY(!has(out, "(declare-sort X"));
+        // A datatype declaration provides its members; declaring them again
+        // beside it makes the script refuse itself.
+        VERIFY(!has(out, "(declare-fun hd"));
+    }
+    {
+        // Plural `declare-datatypes`, where the arity in the header and the
+        // length of the `par` list are two statements of the same fact.
+        const std::string out = roundTrip(
+            "(declare-datatypes ((L 1)) ((par (X) ((nil) (cons (hd X) (tl (L X)))))))\n"
+            "(declare-const b (L Bool))\n(assert (hd b))\n(check-sat)\n",
+            "plural declare-datatypes");
+        VERIFY(has(out, "(L 1)"));
+    }
+    {
+        // Two parameters, so nothing here is a one-parameter special case and
+        // the substitution has to be positional.
+        const std::string out = roundTrip(
+            "(declare-datatype P (par (A B) ((mk (fst A) (snd B)))))\n"
+            "(declare-const p (P Int Bool))\n"
+            "(assert (and (snd p) (= (fst p) 1)))\n(check-sat)\n",
+            "two parameters");
+        VERIFY(has(out, "(P 2)"));
+        VERIFY(has(out, "(par (A B)"));
+    }
+
+    // ---- The selector's sort follows the ARGUMENT. --------------------------
+    {
+        // Both instances in one script. `hd` is used as an Int in one line and
+        // as a Bool in the next, and both must typecheck -- which is only
+        // possible if the sort comes from the argument rather than from the
+        // declaration.
+        roundTrip(std::string(kL) +
+                  "(declare-const a (L Int))\n(declare-const b (L Bool))\n"
+                  "(assert (and (hd b) (= (hd a) 1)))\n(check-sat)\n",
+                  "two instances at once");
+    }
+    {
+        // And the negative: `hd` of an `(L Bool)` is not an Int. Without the
+        // substitution `hd` would have sort `X` and compare against anything.
+        refuses(std::string(kL) + "(declare-const l (L Bool))\n"
+                "(assert (= (hd l) 3))\n(check-sat)\n",
+                "selector at the wrong instance");
+    }
+    {
+        // Nested: `(L (L Int))`, where the argument is itself an instance.
+        roundTrip(std::string(kL) +
+                  "(declare-const ll (L (L Int)))\n"
+                  "(assert (= (hd (hd ll)) 1))\n(check-sat)\n",
+                  "instance as its own argument");
+    }
+
+    // ---- `as` on a nullary constructor, and the print that keeps it. -------
+    {
+        // In the OPERATOR position of an application.
+        const std::string out =
+            roundTrip(std::string(kL) + "(declare-const l (L Int))\n"
+                      "(assert (= l (as nil (L Int))))\n(check-sat)\n",
+                      "as-ascribed nullary constructor");
+        // This is the assertion the dump used to fail: the ascription is the
+        // only thing naming the instance, so printing `nil` loses it.
+        VERIFY(has(out, "(as nil (L Int))"));
+    }
+    {
+        // As an ARGUMENT, where the constructor around it is what pins the
+        // instance -- the ascription is still required, because `cons` cannot
+        // constrain its second argument before knowing its first.
+        const std::string out =
+            roundTrip(std::string(kL) + "(declare-const l (L Int))\n"
+                      "(assert (= l (cons 1 (as nil (L Int)))))\n(check-sat)\n",
+                      "ascription nested in an application");
+        VERIFY(has(out, "(as nil (L Int))"));
+    }
+    {
+        // Two ascriptions of the SAME constructor at different instances are
+        // different terms. Nodes are hash-consed on name and children, and a
+        // nullary constructor has neither to tell them apart -- so if the sort
+        // did not participate, these would be one node and this would
+        // typecheck.
+        refuses(std::string(kL) +
+                "(assert (= (as nil (L Int)) (as nil (L Bool))))\n(check-sat)\n",
+                "equality across two instances");
+    }
+    {
+        // `as` is for constructors. A selector ascribed this way is not a term.
+        refuses(std::string(kL) + "(declare-const l (L Int))\n"
+                "(assert (= l (as hd (L Int))))\n(check-sat)\n",
+                "as applied to a selector");
+    }
+
+    // ---- A sort constructor is not a sort. ---------------------------------
+    {
+        // Used with no arguments.
+        refuses(std::string(kL) + "(declare-const l L)\n(check-sat)\n",
+                "parametric datatype used bare");
+    }
+    {
+        // Used with too many.
+        refuses(std::string(kL) + "(declare-const l (L Int Int))\n(check-sat)\n",
+                "parametric datatype over-applied");
+    }
+    {
+        // The parameter is in scope only inside the declaration, so it must
+        // not leak out as a declared sort afterwards.
+        refuses(std::string(kL) + "(declare-const x X)\n(check-sat)\n",
+                "parameter used as a sort outside its declaration");
+    }
+
+    // ---- Non-parametric datatypes are untouched. ---------------------------
+    {
+        // The case every existing script is. `par` adds a form; it must not
+        // change the output of a declaration that does not use it, so this is
+        // asserted as text.
+        const std::string out = roundTrip(
+            "(declare-datatype Lst ((nil) (cons (hd Int) (tl Lst))))\n"
+            "(declare-const l Lst)\n(assert ((_ is cons) l))\n(check-sat)\n",
+            "non-parametric datatype");
+        VERIFY(has(out,
+                   "(declare-datatypes ((Lst 0)) (((nil) (cons (hd Int) (tl Lst)))))"));
+        VERIFY(!has(out, "par"));
+        // A nullary constructor of a non-parametric datatype has no instance to
+        // name, so it must keep printing bare -- the ascription is added only
+        // where it is required.
+        const std::string out2 = roundTrip(
+            "(declare-datatype Lst ((nil) (cons (hd Int) (tl Lst))))\n"
+            "(declare-const l Lst)\n(assert (= l nil))\n(check-sat)\n",
+            "non-parametric nullary constructor");
+        VERIFY(has(out2, "nil)"));
+        VERIFY(!has(out2, "(as nil"));
+    }
+
+    std::cout << "All parametric-datatype tests passed." << std::endl;
+    return 0;
+}


### PR DESCRIPTION
SMT-LIB 2.6 lets a datatype declaration abstract over sorts:

```smt2
(declare-datatype L (par (X) ((nil) (cons (hd X) (tl (L X))))))
```

The parser had no `par`, so a conforming script stopped at its first such declaration.

Reading `par` is the small half. The rest is that `L` is then a sort **constructor** rather than a sort, and several places treated a datatype name as a complete sort.

### A selector's sort follows the argument, not the declaration

`hd` is declared to return `X` and must yield `Int` on an `(L Int)`. The datatype interception path in `parseOper` used the declared sort unsubstituted, so a selector had sort `X` and compared equal to anything: `(assert (= (hd l) 3))` typechecked for an `l` of sort `(L Bool)`.

### A nullary constructor needs its ascription, and the ascription must survive printing

`nil` names a member of every instance of `L` at once, and with no argument there is nothing to infer the instance from — which is why the standard requires `(as nil (L Int))`. Both `as` forms are now read: as the operator of an application, and as a whole term.

Printing was the sharper half. `dumpSMT2` emitted the bare constructor name, so a term built at a definite sort came back out at none and **the dump did not read back**:

```smt2
(assert (= l (as nil (L Int))))     ; in
(assert (= l nil))                  ; out  ->  Type mismatch in equality
```

A nullary constructor whose sort carries arguments now prints with its ascription; one whose sort does not is unchanged.

### `L` alone is not a sort

It was accepted, and a variable declared at it dumped as `(declare-fun l () L)` — an arity-1 name used at arity 0. It is now an arity mismatch naming the datatype and how many arguments it takes.

`Sort::toString` and `Sort::operator==` for datatypes were likewise name-only, so `(L Int)` and `(L Bool)` printed and compared as `L`.

### Compatibility

A datatype declaration that uses no parameters produces byte-for-byte the output it did before. `test/regression/test_parametric_datatypes.cpp` asserts that as text, alongside the round trip `text -> parse -> dump -> parse -> dump` on every positive case and six refusals (over-applied, under-applied, parameter escaping its scope, `as` on a selector, a selector at the wrong instance, equality across two instances).

Each of the three fixes was breakage-probed: reverting it individually makes the new test fail.

### Stacking

Based on `fix/mutually-recursive-datatypes` (#56), which is itself stacked on #57/#58/#59. Review that one first. 58 tests pass in Debug and Release.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)