### PR TITLE
ci: publishable PyPI release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     
     - name: Cache dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: |
           ~/.cache/apt
@@ -98,10 +98,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -6,6 +6,11 @@ name: Build Wheels
 #  - Windows AMD64 (GMP/MPFR from vcpkg, vendored by delvewheel)
 # plus the sdist. Runs on demand (workflow_dispatch) and on version tags;
 # a v* tag additionally publishes to PyPI via trusted publishing.
+#
+# The macOS deployment target matches the runner's OS because the Homebrew
+# GMP/MPFR bottles are built for it — delocate refuses to vendor a dylib
+# whose minimum OS is newer than the wheel's target. Older macOS falls back
+# to the sdist.
 
 on:
   workflow_dispatch:
@@ -13,6 +18,22 @@ on:
     tags: [ "v*" ]
 
 jobs:
+  check_version:
+    name: Tag matches pyproject version
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compare tag with pyproject.toml
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          version=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "$tag" != "$version" ]; then
+            echo "::error::Tag v$tag does not match pyproject.toml version $version"
+            exit 1
+          fi
+
   build_sdist:
     name: Build sdist
     runs-on: ubuntu-latest
@@ -33,7 +54,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
+        include:
+          - os: ubuntu-latest
+          - os: macos-15-intel   # last free x86_64 macOS runner (until Aug 2027)
+            macos-target: "15.0"
+          - os: macos-14         # arm64
+            macos-target: "14.0"
+          - os: windows-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -57,11 +84,15 @@ jobs:
           # manylinux containers are yum-based
           CIBW_BEFORE_ALL_LINUX: yum install -y gmp-devel mpfr-devel
           CIBW_ENVIRONMENT_MACOS: >-
+            MACOSX_DEPLOYMENT_TARGET=${{ matrix.macos-target }}
             CMAKE_ARGS="-DCMAKE_PREFIX_PATH=/opt/homebrew;/usr/local"
           CIBW_ENVIRONMENT_WINDOWS: >-
             CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake"
           CIBW_BEFORE_BUILD_WINDOWS: pip install delvewheel
-          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair -w {dest_dir} {wheel}
+          # gmp/mpfr DLLs live in the vcpkg tree, which is not on PATH
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
+            delvewheel repair -w {dest_dir}
+            --add-path C:/vcpkg/installed/x64-windows/bin {wheel}
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {project}/test/python -q
 
@@ -72,7 +103,7 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    needs: [build_wheels, build_sdist]
+    needs: [check_version, build_wheels, build_sdist]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: pypi

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -74,9 +74,9 @@ jobs:
         run: vcpkg install gmp:x64-windows mpfr:x64-windows
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3
+        uses: pypa/cibuildwheel@v4.2.0  # no floating major tag exists
         env:
-          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
           CIBW_SKIP: "pp* *musllinux*"
           CIBW_ARCHS_LINUX: x86_64
           CIBW_ARCHS_MACOS: auto

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -71,7 +71,12 @@ jobs:
 
       - name: Install GMP/MPFR (Windows, vcpkg)
         if: runner.os == 'Windows'
-        run: vcpkg install gmp:x64-windows mpfr:x64-windows
+        # the preinstalled vcpkg ports tree goes stale and its msys2
+        # download URLs start 404ing — update it first
+        run: |
+          git -C C:\vcpkg pull --ff-only
+          C:\vcpkg\bootstrap-vcpkg.bat -disableMetrics
+          vcpkg install gmp:x64-windows mpfr:x64-windows
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v4.2.0  # no floating major tag exists
@@ -83,9 +88,11 @@ jobs:
           CIBW_ARCHS_WINDOWS: AMD64
           # manylinux containers are yum-based
           CIBW_BEFORE_ALL_LINUX: yum install -y gmp-devel mpfr-devel
+          # no CMAKE_PREFIX_PATH here: FindGMP/FindMPFR query `brew --prefix`
+          # themselves, and a -D override would clobber the pybind11 search
+          # path that scikit-build-core injects
           CIBW_ENVIRONMENT_MACOS: >-
             MACOSX_DEPLOYMENT_TARGET=${{ matrix.macos-target }}
-            CMAKE_ARGS="-DCMAKE_PREFIX_PATH=/opt/homebrew;/usr/local"
           CIBW_ENVIRONMENT_WINDOWS: >-
             CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake"
           CIBW_BEFORE_BUILD_WINDOWS: pip install delvewheel

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,7 +23,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Compare tag with pyproject.toml
         run: |
@@ -38,12 +38,12 @@ jobs:
     name: Build sdist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Build sdist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: sdist
           path: dist/*.tar.gz
@@ -63,7 +63,7 @@ jobs:
           - os: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install GMP/MPFR (macOS)
         if: runner.os == 'macOS'
@@ -82,7 +82,8 @@ jobs:
         uses: pypa/cibuildwheel@v4.2.0  # no floating major tag exists
         env:
           CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
-          CIBW_SKIP: "pp* *musllinux*"
+          # PyPy is opt-in since cibuildwheel v4, no pp* skip needed
+          CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS_LINUX: x86_64
           CIBW_ARCHS_MACOS: auto
           CIBW_ARCHS_WINDOWS: AMD64
@@ -103,7 +104,7 @@ jobs:
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {project}/test/python -q
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.os }}
           path: wheelhouse/*.whl
@@ -117,7 +118,7 @@ jobs:
     permissions:
       id-token: write  # trusted publishing, no API token needed
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ __pycache__/
 *.pyc
 dist/
 *.egg-info/
+
+# Claude Code local state
+.claude/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # SOMTParser
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![PyPI](https://img.shields.io/pypi/v/somtparser.svg)](https://pypi.org/project/somtparser/)
+[![Python](https://img.shields.io/pypi/pyversions/somtparser.svg)](https://pypi.org/project/somtparser/)
 
 **SOMTParser** is a solver-independent C++17 front-end library for SMT-LIB and OMT (Optimization Modulo Theories). It parses input into a **typed DAG-based intermediate representation (IR)** and provides modular front-end functionality—parsing, type checking, traversals, rewriting, and formula-level processing—around this IR, separating reusable front-end logic from backend reasoning and reducing the effort to build new solvers and SMT-based tools.
 
@@ -14,7 +16,7 @@
 ## Key Features
 
 - **SMT-LIB2 support**: Compliant with the SMT-LIB2 specification; multiple logics and theories.
-- **FloatingPoint dialect**: By default the parser accepts small **lenient** extensions (e.g. unary `fp.sqrt` canonicalized to `(fp.sqrt RNE …)` in the IR, and aliases like `fp.=`). For **stricter** surface syntax aligned with the official FloatingPoint theory, enable `strict_smtlib_fp` (`Parser::setStrictSmtlib(true)` or `GlobalOptions::setOption("strict_smtlib_fp", "true")`). Details and the full matrix are in [`gaps.md`](gaps.md) (section *FloatingPoint: SMT-LIB theory vs lenient extensions*).
+- **FloatingPoint dialect**: By default the parser accepts small **lenient** extensions (e.g. unary `fp.sqrt` canonicalized to `(fp.sqrt RNE …)` in the IR, and aliases like `fp.=`). For **stricter** surface syntax aligned with the official FloatingPoint theory, enable `strict_smtlib_fp` (`Parser::setStrictSmtlib(true)` or `GlobalOptions::setOption("strict_smtlib_fp", "true")`).
 - **Multi-theory**: Booleans, integer/real arithmetic, bitvectors, IEEE-754 floating point, strings and regular expressions, arrays.
 - **Typed DAG IR**: Structure sharing and canonicalization for a more compact representation and easier analysis/transformation.
 - **OMT support**: Parses intermediate syntax such as `assert-soft`, `maximize`/`minimize`, `define-objective`, `lex-optimize`/`pareto-optimize`/`box-optimize`, `maxsat`/`minsat`, managed by `ObjectiveManager`.
@@ -193,12 +195,25 @@ parsing, expression-building, transformation, model-evaluation and OMT API.
 ### Install
 
 ```bash
-# from the repository root (requires a C++17 compiler, GMP and MPFR)
+pip install somtparser
+```
+
+Prebuilt wheels are published on [PyPI](https://pypi.org/project/somtparser/) for
+CPython 3.9–3.13 on Linux x86_64 (manylinux), macOS (Intel needs macOS 15+,
+Apple Silicon needs macOS 14+) and Windows AMD64, with GMP/MPFR bundled — no
+system dependencies required.
+
+On any other platform `pip` falls back to building from the sdist, which needs
+a C++17 compiler, CMake, GMP and MPFR (see
+[System Requirements](#system-requirements)). The same applies when installing
+from a checkout:
+
+```bash
+# from the repository root
 pip install .
 ```
 
 This builds a wheel via scikit-build-core with the static C++ core compiled in.
-(A prebuilt package on PyPI — `pip install somtparser` — is planned.)
 
 ### Quick Start
 
@@ -823,6 +838,22 @@ We welcome contributions from the community! Please see our [CONTRIBUTORS.md](CO
 ## Development Status
 
 **Active Development** — The project is under continuous maintenance and development; new features and optimizations are added regularly.
+
+## Releasing (maintainers)
+
+PyPI releases are fully automated by
+[`.github/workflows/wheels.yml`](.github/workflows/wheels.yml):
+
+1. Bump `version` in `pyproject.toml` on `main`.
+2. Tag and push: `git tag vX.Y.Z && git push origin vX.Y.Z` (the workflow
+   fails if the tag does not match the `pyproject.toml` version).
+3. The workflow builds the sdist and all wheels, runs the Python test suite
+   against each wheel, and publishes to PyPI via
+   [trusted publishing](https://docs.pypi.org/trusted-publishers/) (GitHub
+   environment `pypi`, no API token involved).
+
+To dry-run the wheel builds without publishing, trigger the workflow manually
+from the Actions tab (`workflow_dispatch`); wheels are attached as artifacts.
 
 ## Contact
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: C++",
     "Topic :: Scientific/Engineering",
     "License :: OSI Approved :: MIT License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "somtparser"
-version = "0.2.0"
+version = "0.4.0"
 description = "Python bindings for SOMTParser - a solver-independent SMT-LIB/OMT front-end library"
 readme = "README.md"
 license = {text = "MIT"}
@@ -33,6 +33,7 @@ Homepage = "https://github.com/fuqi-jia/SOMTParser"
 test = ["pytest>=7.0"]
 
 [tool.scikit-build]
+sdist.exclude = [".claude"]
 cmake.args = [
     "-DBUILD_PYTHON=ON",
     "-DBUILD_SHARED_LIBS=OFF",


### PR DESCRIPTION
Makes the `wheels.yml` release workflow actually runnable and documents the PyPI story.

## What changed
- **wheels.yml**: `macos-13` runners were retired 2025-12-04 — x86_64 wheels now build on `macos-15-intel`. Set `MACOSX_DEPLOYMENT_TARGET` to the runner OS (delocate refuses to vendor Homebrew GMP/MPFR dylibs into a wheel with an older target), point delvewheel at the vcpkg `bin` directory (not on `PATH`), and add a job that refuses to publish when the pushed tag disagrees with `pyproject.toml`.
- **pyproject.toml**: version 0.2.0 → 0.4.0 (tags already reach v0.3.0); exclude `.claude/` from the sdist (untracked-but-not-ignored files were being packaged).
- **README**: `pip install somtparser` as the primary install path, wheel platform matrix, maintainer release steps; removed a dead `gaps.md` link.

## Verification
- sdist builds locally (440K, `.claude` no longer included)
- `workflow_dispatch` run of the full wheel matrix on this branch: https://github.com/fuqi-jia/SOMTParser/actions/runs/32219671907

🤖 Generated with [Claude Code](https://claude.com/claude-code)